### PR TITLE
Backward compatiblity of new block format with cross messages

### DIFF
--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -741,10 +741,6 @@ func (filec *FilecoinEC) validateMsgMeta(ctx context.Context, msg *types.BlockMs
 	store := blockadt.WrapStore(ctx, cbor.NewCborStore(bstore.NewMemory()))
 	bmArr := blockadt.MakeEmptyArray(store)
 	smArr := blockadt.MakeEmptyArray(store)
-	emptyroot, err := blockadt.MakeEmptyArray(store).Root()
-	if err != nil {
-		return err
-	}
 
 	for i, m := range msg.BlsMessages {
 		c := cbg.CborCid(m)
@@ -770,11 +766,13 @@ func (filec *FilecoinEC) validateMsgMeta(ctx context.Context, msg *types.BlockMs
 		return err
 	}
 
-	mrcid, err := store.Put(store.Context(), &types.MsgMeta{
+	// TODO FIXME: No support for the application of cross-messages for
+	// filecoin consensus. To support cross-messages with Filecoin consensus this
+	// will need to change. For the meantime, we just process the OldMsgMeta as
+	// we did in previous versions.
+	mrcid, err := store.Put(store.Context(), &types.OldMsgMeta{
 		BlsMessages:   bmroot,
 		SecpkMessages: smroot,
-		// NOTE: No support for cross messages in filcns at this moment
-		CrossMessages: emptyroot,
 	})
 
 	if err != nil {

--- a/chain/consensus/filcns/filecoin.go
+++ b/chain/consensus/filcns/filecoin.go
@@ -766,10 +766,10 @@ func (filec *FilecoinEC) validateMsgMeta(ctx context.Context, msg *types.BlockMs
 		return err
 	}
 
-	// TODO FIXME: No support for the application of cross-messages for
+	// TODO FIXME: No support for the application of cross-messages with
 	// filecoin consensus. To support cross-messages with Filecoin consensus this
-	// will need to change. For the meantime, we just process the OldMsgMeta as
-	// we did in previous versions.
+	// will need to change. In the meantime, we just process the OldMsgMeta as
+	// we did in previous versions and we disregard cross-msgs.
 	mrcid, err := store.Put(store.Context(), &types.OldMsgMeta{
 		BlsMessages:   bmroot,
 		SecpkMessages: smroot,

--- a/chain/exchange/cbor_gen.go
+++ b/chain/exchange/cbor_gen.go
@@ -259,14 +259,300 @@ func (t *Response) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufCompactedMessages = []byte{134}
+var lengthBufOldCompactedMessages = []byte{132}
 
-func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
+func (t *OldCompactedMessages) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufCompactedMessages); err != nil {
+	if _, err := w.Write(lengthBufOldCompactedMessages); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Bls ([]*types.Message) (slice)
+	if len(t.Bls) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Bls was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Bls))); err != nil {
+		return err
+	}
+	for _, v := range t.Bls {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+
+	// t.BlsIncludes ([][]uint64) (slice)
+	if len(t.BlsIncludes) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.BlsIncludes was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.BlsIncludes))); err != nil {
+		return err
+	}
+	for _, v := range t.BlsIncludes {
+		if len(v) > cbg.MaxLength {
+			return xerrors.Errorf("Slice value in field v was too long")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(v))); err != nil {
+			return err
+		}
+		for _, v := range v {
+			if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+				return err
+			}
+		}
+	}
+
+	// t.Secpk ([]*types.SignedMessage) (slice)
+	if len(t.Secpk) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Secpk was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.Secpk))); err != nil {
+		return err
+	}
+	for _, v := range t.Secpk {
+		if err := v.MarshalCBOR(w); err != nil {
+			return err
+		}
+	}
+
+	// t.SecpkIncludes ([][]uint64) (slice)
+	if len(t.SecpkIncludes) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.SecpkIncludes was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.SecpkIncludes))); err != nil {
+		return err
+	}
+	for _, v := range t.SecpkIncludes {
+		if len(v) > cbg.MaxLength {
+			return xerrors.Errorf("Slice value in field v was too long")
+		}
+
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(v))); err != nil {
+			return err
+		}
+		for _, v := range v {
+			if err := cbg.CborWriteHeader(w, cbg.MajUnsignedInt, uint64(v)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *OldCompactedMessages) UnmarshalCBOR(r io.Reader) error {
+	*t = OldCompactedMessages{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 4 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Bls ([]*types.Message) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Bls: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Bls = make([]*types.Message, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v types.Message
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Bls[i] = &v
+	}
+
+	// t.BlsIncludes ([][]uint64) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.BlsIncludes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.BlsIncludes = make([][]uint64, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.BlsIncludes[i]: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.BlsIncludes[i] = make([]uint64, extra)
+			}
+
+			for j := 0; j < int(extra); j++ {
+
+				maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return xerrors.Errorf("failed to read uint64 for t.BlsIncludes[i] slice: %w", err)
+				}
+
+				if maj != cbg.MajUnsignedInt {
+					return xerrors.Errorf("value read for array t.BlsIncludes[i] was not a uint, instead got %d", maj)
+				}
+
+				t.BlsIncludes[i][j] = uint64(val)
+			}
+
+		}
+	}
+
+	// t.Secpk ([]*types.SignedMessage) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.Secpk: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.Secpk = make([]*types.SignedMessage, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		var v types.SignedMessage
+		if err := v.UnmarshalCBOR(br); err != nil {
+			return err
+		}
+
+		t.Secpk[i] = &v
+	}
+
+	// t.SecpkIncludes ([][]uint64) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.SecpkIncludes: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.SecpkIncludes = make([][]uint64, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.SecpkIncludes[i]: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.SecpkIncludes[i] = make([]uint64, extra)
+			}
+
+			for j := 0; j < int(extra); j++ {
+
+				maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return xerrors.Errorf("failed to read uint64 for t.SecpkIncludes[i] slice: %w", err)
+				}
+
+				if maj != cbg.MajUnsignedInt {
+					return xerrors.Errorf("value read for array t.SecpkIncludes[i] was not a uint, instead got %d", maj)
+				}
+
+				t.SecpkIncludes[i][j] = uint64(val)
+			}
+
+		}
+	}
+
+	return nil
+}
+
+var lengthBufNewCompactedMessages = []byte{134}
+
+func (t *NewCompactedMessages) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufNewCompactedMessages); err != nil {
 		return err
 	}
 
@@ -385,8 +671,8 @@ func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *CompactedMessages) UnmarshalCBOR(r io.Reader) error {
-	*t = CompactedMessages{}
+func (t *NewCompactedMessages) UnmarshalCBOR(r io.Reader) error {
+	*t = NewCompactedMessages{}
 
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)

--- a/chain/exchange/protocol.go
+++ b/chain/exchange/protocol.go
@@ -202,17 +202,17 @@ type NewCompactedMessages struct {
 }
 
 func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
-	// NOTE: I don't think its needed to added a handler here to determine
+	// NOTE: I don't think we need to add a handler here to determine
 	// if to marshal a new or old CompactedMessages format. UnmarshalCBOR will
 	// handle any format conveniently. However, if something breaks
-	// in the chain exchange protocol bear in mind that we are marshalling new
+	// in the chain exchange protocol bear in mind that we are _always_ marshalling new
 	// CompactedMessages type here.
 	bm := NewCompactedMessages{t.Bls, t.BlsIncludes, t.Secpk, t.SecpkIncludes, t.Cross, t.CrossIncludes}
 	return bm.MarshalCBOR(w)
 }
 
 // isOldCompacted checks if a new or old version of compactedMesasges is being
-// send in the reader.
+// sent in the reader.
 func isOldCompacted(r io.Reader) (bool, io.Reader, error) {
 	scratch := make([]byte, 1)
 	n, err := r.Read(scratch[:1])

--- a/chain/exchange/protocol.go
+++ b/chain/exchange/protocol.go
@@ -1,6 +1,9 @@
 package exchange
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/filecoin-project/lotus/build"
@@ -168,6 +171,103 @@ type CompactedMessages struct {
 	CrossIncludes [][]uint64
 }
 
+// OldCompactedMessages is as the serialized representation of
+// previously validated blocks that didn't support the inclusion of
+// cross-net messages inside the block.
+//
+// When a block without cross-messages is received through the wire,
+// it is unmarshalled into and OldCompactedMessage that is afterwards
+// translated into a CompactedMessage without cross-mesasges.
+type OldCompactedMessages struct {
+	Bls         []*types.Message
+	BlsIncludes [][]uint64
+
+	Secpk         []*types.SignedMessage
+	SecpkIncludes [][]uint64
+}
+
+// NewCompactedMesasges is the serialized representation of a modern
+// compactedMessages including cross-net messages. This is an auxiliary
+// type used to ensure backward compatibility with previous versions of
+// compactedMessages used in the protocol.
+type NewCompactedMessages struct {
+	Bls         []*types.Message
+	BlsIncludes [][]uint64
+
+	Secpk         []*types.SignedMessage
+	SecpkIncludes [][]uint64
+
+	Cross         []*types.Message
+	CrossIncludes [][]uint64
+}
+
+func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
+	// NOTE: I don't think its needed to added a handler here to determine
+	// if to marshal a new or old CompactedMessages format. UnmarshalCBOR will
+	// handle any format conveniently. However, if something breaks
+	// in the chain exchange protocol bear in mind that we are marshalling new
+	// CompactedMessages type here.
+	bm := NewCompactedMessages{t.Bls, t.BlsIncludes, t.Secpk, t.SecpkIncludes, t.Cross, t.CrossIncludes}
+	return bm.MarshalCBOR(w)
+}
+
+// isOldCompacted checks if a new or old version of compactedMesasges is being
+// send in the reader.
+func isOldCompacted(r io.Reader) (bool, io.Reader, error) {
+	scratch := make([]byte, 1)
+	n, err := r.Read(scratch[:1])
+	if err != nil {
+		return false, nil, err
+	}
+	if n != 1 {
+		return false, nil, fmt.Errorf("failed to read a byte")
+	}
+
+	extra := scratch[0] & 0x1f
+	u := io.MultiReader(bytes.NewReader(scratch[:1]), r)
+	// The check is performed through the number of fields in the
+	// type being sent.
+	if extra != 4 {
+		return false, u, err
+	}
+	return true, u, err
+}
+
+func (t *CompactedMessages) UnmarshalCBOR(r io.Reader) error {
+	isOld, u, err := isOldCompacted(r)
+	if err != nil {
+		return err
+	}
+	if isOld {
+		var obm OldCompactedMessages
+		if err := obm.UnmarshalCBOR(u); err != nil {
+			return err
+		}
+		// unwrapping old into CompactedMessages
+		t.Bls = obm.Bls
+		t.BlsIncludes = obm.BlsIncludes
+		t.Secpk = obm.Secpk
+		t.SecpkIncludes = obm.SecpkIncludes
+		t.Cross = make([]*types.Message, 0)
+		t.CrossIncludes = make([][]uint64, 0)
+		return nil
+	}
+
+	var nbm NewCompactedMessages
+	if err := nbm.UnmarshalCBOR(u); err != nil {
+		return err
+	}
+	// unwrapping new into CompactedMessages
+	t.Bls = nbm.Bls
+	t.BlsIncludes = nbm.BlsIncludes
+	t.Secpk = nbm.Secpk
+	t.SecpkIncludes = nbm.SecpkIncludes
+	t.Cross = nbm.Cross
+	t.CrossIncludes = nbm.CrossIncludes
+
+	return nil
+}
+
 // Response that has been validated according to the protocol
 // and can be safely accessed.
 type validatedResponse struct {
@@ -201,8 +301,12 @@ func (res *validatedResponse) toFullTipSets() []*store.FullTipSet {
 			for _, mi := range msgs.SecpkIncludes[blockIdx] {
 				fb.SecpkMessages = append(fb.SecpkMessages, msgs.Secpk[mi])
 			}
-			for _, mi := range msgs.CrossIncludes[blockIdx] {
-				fb.CrossMessages = append(fb.CrossMessages, msgs.Cross[mi])
+
+			// Only validate tipset with cross-messages if any are present.
+			if msgs.CrossIncludes != nil && len(msgs.CrossIncludes) > 0 {
+				for _, mi := range msgs.CrossIncludes[blockIdx] {
+					fb.CrossMessages = append(fb.CrossMessages, msgs.Cross[mi])
+				}
 			}
 
 			fts.Blocks = append(fts.Blocks, fb)

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1196,7 +1196,7 @@ func persistMessages(ctx context.Context, bs bstore.Blockstore, bst *exchange.Co
 		}
 	}
 
-	// TODO: Persist cross-messages, or as they are stored in SCA we don't need it?
+	// TODO: Persist cross-messages, or as they are stored in SCA we don't need to?
 
 	return nil
 }

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -134,6 +134,11 @@ type MsgMeta struct {
 	CrossMessages cid.Cid
 }
 
+type OldMsgMeta struct {
+	BlsMessages   cid.Cid
+	SecpkMessages cid.Cid
+}
+
 func (mm *MsgMeta) Cid() cid.Cid {
 	b, err := mm.ToStorageBlock()
 	if err != nil {

--- a/chain/types/blockmsg.go
+++ b/chain/types/blockmsg.go
@@ -22,6 +22,8 @@ type OldBlockMsg struct {
 func DecodeBlockMsg(b []byte) (*BlockMsg, error) {
 	var bm BlockMsg
 	if err := bm.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
+		// If we couldn't unmarshal the new version of block format,
+		// we try with the old version.
 		var obm OldBlockMsg
 		if err := obm.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
 			return nil, err

--- a/chain/types/blockmsg.go
+++ b/chain/types/blockmsg.go
@@ -13,10 +13,22 @@ type BlockMsg struct {
 	CrossMessages []cid.Cid
 }
 
+type OldBlockMsg struct {
+	Header        *BlockHeader
+	BlsMessages   []cid.Cid
+	SecpkMessages []cid.Cid
+}
+
 func DecodeBlockMsg(b []byte) (*BlockMsg, error) {
 	var bm BlockMsg
 	if err := bm.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
-		return nil, err
+		var obm OldBlockMsg
+		if err := obm.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
+			return nil, err
+		}
+		bm.Header = obm.Header
+		bm.BlsMessages = obm.BlsMessages
+		bm.SecpkMessages = obm.SecpkMessages
 	}
 
 	return &bm, nil

--- a/chain/types/cbor_gen.go
+++ b/chain/types/cbor_gen.go
@@ -1019,6 +1019,79 @@ func (t *MsgMeta) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
+var lengthBufOldMsgMeta = []byte{130}
+
+func (t *OldMsgMeta) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufOldMsgMeta); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.BlsMessages (cid.Cid) (struct)
+
+	if err := cbg.WriteCidBuf(scratch, w, t.BlsMessages); err != nil {
+		return xerrors.Errorf("failed to write cid field t.BlsMessages: %w", err)
+	}
+
+	// t.SecpkMessages (cid.Cid) (struct)
+
+	if err := cbg.WriteCidBuf(scratch, w, t.SecpkMessages); err != nil {
+		return xerrors.Errorf("failed to write cid field t.SecpkMessages: %w", err)
+	}
+
+	return nil
+}
+
+func (t *OldMsgMeta) UnmarshalCBOR(r io.Reader) error {
+	*t = OldMsgMeta{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 2 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.BlsMessages (cid.Cid) (struct)
+
+	{
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.BlsMessages: %w", err)
+		}
+
+		t.BlsMessages = c
+
+	}
+	// t.SecpkMessages (cid.Cid) (struct)
+
+	{
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.SecpkMessages: %w", err)
+		}
+
+		t.SecpkMessages = c
+
+	}
+	return nil
+}
+
 var lengthBufActor = []byte{132}
 
 func (t *Actor) MarshalCBOR(w io.Writer) error {
@@ -1448,6 +1521,150 @@ func (t *BlockMsg) UnmarshalCBOR(r io.Reader) error {
 			return xerrors.Errorf("reading cid field t.CrossMessages failed: %w", err)
 		}
 		t.CrossMessages[i] = c
+	}
+
+	return nil
+}
+
+var lengthBufOldBlockMsg = []byte{131}
+
+func (t *OldBlockMsg) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+	if _, err := w.Write(lengthBufOldBlockMsg); err != nil {
+		return err
+	}
+
+	scratch := make([]byte, 9)
+
+	// t.Header (types.BlockHeader) (struct)
+	if err := t.Header.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.BlsMessages ([]cid.Cid) (slice)
+	if len(t.BlsMessages) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.BlsMessages was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.BlsMessages))); err != nil {
+		return err
+	}
+	for _, v := range t.BlsMessages {
+		if err := cbg.WriteCidBuf(scratch, w, v); err != nil {
+			return xerrors.Errorf("failed writing cid field t.BlsMessages: %w", err)
+		}
+	}
+
+	// t.SecpkMessages ([]cid.Cid) (slice)
+	if len(t.SecpkMessages) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.SecpkMessages was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.SecpkMessages))); err != nil {
+		return err
+	}
+	for _, v := range t.SecpkMessages {
+		if err := cbg.WriteCidBuf(scratch, w, v); err != nil {
+			return xerrors.Errorf("failed writing cid field t.SecpkMessages: %w", err)
+		}
+	}
+	return nil
+}
+
+func (t *OldBlockMsg) UnmarshalCBOR(r io.Reader) error {
+	*t = OldBlockMsg{}
+
+	br := cbg.GetPeeker(r)
+	scratch := make([]byte, 8)
+
+	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajArray {
+		return fmt.Errorf("cbor input should be of type array")
+	}
+
+	if extra != 3 {
+		return fmt.Errorf("cbor input had wrong number of fields")
+	}
+
+	// t.Header (types.BlockHeader) (struct)
+
+	{
+
+		b, err := br.ReadByte()
+		if err != nil {
+			return err
+		}
+		if b != cbg.CborNull[0] {
+			if err := br.UnreadByte(); err != nil {
+				return err
+			}
+			t.Header = new(BlockHeader)
+			if err := t.Header.UnmarshalCBOR(br); err != nil {
+				return xerrors.Errorf("unmarshaling t.Header pointer: %w", err)
+			}
+		}
+
+	}
+	// t.BlsMessages ([]cid.Cid) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.BlsMessages: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.BlsMessages = make([]cid.Cid, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("reading cid field t.BlsMessages failed: %w", err)
+		}
+		t.BlsMessages[i] = c
+	}
+
+	// t.SecpkMessages ([]cid.Cid) (slice)
+
+	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.SecpkMessages: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.SecpkMessages = make([]cid.Cid, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("reading cid field t.SecpkMessages failed: %w", err)
+		}
+		t.SecpkMessages[i] = c
 	}
 
 	return nil

--- a/gen/main.go
+++ b/gen/main.go
@@ -24,9 +24,11 @@ func main() {
 		types.Message{},
 		types.SignedMessage{},
 		types.MsgMeta{},
+		types.OldMsgMeta{},
 		types.Actor{},
 		types.MessageReceipt{},
 		types.BlockMsg{},
+		types.OldBlockMsg{},
 		types.ExpTipSet{},
 		types.BeaconEntry{},
 		types.StateRoot{},
@@ -81,7 +83,8 @@ func main() {
 	err = gen.WriteTupleEncodersToFile("./chain/exchange/cbor_gen.go", "exchange",
 		exchange.Request{},
 		exchange.Response{},
-		exchange.CompactedMessages{},
+		exchange.OldCompactedMessages{},
+		exchange.NewCompactedMessages{},
 		exchange.BSTipSet{},
 	)
 	if err != nil {


### PR DESCRIPTION
In https://github.com/filecoin-project/eudico/pull/85 we introduced a new block format that included a field to include cross messages. This PR fixes compatibility issues with the previous block version that was preventing versions of Eudico that supported the new block format to sync with previous versions of the client.