### PR TITLE
Add sync cmd to sync with subnet without adding collateral

### DIFF
--- a/api/api_hierarchical.go
+++ b/api/api_hierarchical.go
@@ -15,8 +15,8 @@ type HierarchicalCns interface {
 	AddSubnet(ctx context.Context, wallet address.Address, parent hierarchical.SubnetID, name string, consensus uint64, minerStake abi.TokenAmount,
 		checkperiod abi.ChainEpoch, delegminer address.Address) (address.Address, error) // perm:write
 	JoinSubnet(ctx context.Context, wallet address.Address, value abi.TokenAmount, id hierarchical.SubnetID) (cid.Cid, error) // perm:write
-	SyncSubnet(ctx context.Context, id hierarchical.SubnetID) error                                                           // perm:write
-	MineSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID, stop bool) error                        // perm:write
+	SyncSubnet(ctx context.Context, id hierarchical.SubnetID, stop bool) error                                                // perm:write
+	MineSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID, stop bool) error                        // perm:read
 	LeaveSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID) (cid.Cid, error)                       // perm:write
 	KillSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID) (cid.Cid, error)                        // perm:write
 	ListCheckpoints(ctx context.Context, id hierarchical.SubnetID, num int) ([]*schema.Checkpoint, error)                     // perm:read

--- a/api/api_hierarchical.go
+++ b/api/api_hierarchical.go
@@ -15,6 +15,7 @@ type HierarchicalCns interface {
 	AddSubnet(ctx context.Context, wallet address.Address, parent hierarchical.SubnetID, name string, consensus uint64, minerStake abi.TokenAmount,
 		checkperiod abi.ChainEpoch, delegminer address.Address) (address.Address, error) // perm:write
 	JoinSubnet(ctx context.Context, wallet address.Address, value abi.TokenAmount, id hierarchical.SubnetID) (cid.Cid, error) // perm:write
+	SyncSubnet(ctx context.Context, id hierarchical.SubnetID) error                                                           // perm:write
 	MineSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID, stop bool) error                        // perm:write
 	LeaveSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID) (cid.Cid, error)                       // perm:write
 	KillSubnet(ctx context.Context, wallet address.Address, id hierarchical.SubnetID) (cid.Cid, error)                        // perm:write

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -3039,6 +3039,20 @@ func (mr *MockFullNodeMockRecorder) SyncSubmitBlock(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubmitBlock", reflect.TypeOf((*MockFullNode)(nil).SyncSubmitBlock), arg0, arg1)
 }
 
+// SyncSubnet mocks base method.
+func (m *MockFullNode) SyncSubnet(arg0 context.Context, arg1 hierarchical.SubnetID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncSubnet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncSubnet indicates an expected call of SyncSubnet.
+func (mr *MockFullNodeMockRecorder) SyncSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubnet", reflect.TypeOf((*MockFullNode)(nil).SyncSubnet), arg0, arg1)
+}
+
 // SyncUnmarkAllBad mocks base method.
 func (m *MockFullNode) SyncUnmarkAllBad(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -3040,17 +3040,17 @@ func (mr *MockFullNodeMockRecorder) SyncSubmitBlock(arg0, arg1 interface{}) *gom
 }
 
 // SyncSubnet mocks base method.
-func (m *MockFullNode) SyncSubnet(arg0 context.Context, arg1 hierarchical.SubnetID) error {
+func (m *MockFullNode) SyncSubnet(arg0 context.Context, arg1 hierarchical.SubnetID, arg2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncSubnet", arg0, arg1)
+	ret := m.ctrl.Call(m, "SyncSubnet", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SyncSubnet indicates an expected call of SyncSubnet.
-func (mr *MockFullNodeMockRecorder) SyncSubnet(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFullNodeMockRecorder) SyncSubnet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubnet", reflect.TypeOf((*MockFullNode)(nil).SyncSubnet), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubnet", reflect.TypeOf((*MockFullNode)(nil).SyncSubnet), arg0, arg1, arg2)
 }
 
 // SyncUnmarkAllBad mocks base method.

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -569,9 +569,9 @@ type HierarchicalCnsStruct struct {
 
 		ListCheckpoints func(p0 context.Context, p1 hierarchical.SubnetID, p2 int) ([]*schema.Checkpoint, error) `perm:"read"`
 
-		MineSubnet func(p0 context.Context, p1 address.Address, p2 hierarchical.SubnetID, p3 bool) error `perm:"write"`
+		MineSubnet func(p0 context.Context, p1 address.Address, p2 hierarchical.SubnetID, p3 bool) error `perm:"read"`
 
-		SyncSubnet func(p0 context.Context, p1 hierarchical.SubnetID) error `perm:"write"`
+		SyncSubnet func(p0 context.Context, p1 hierarchical.SubnetID, p2 bool) error `perm:"write"`
 
 		ValidateCheckpoint func(p0 context.Context, p1 hierarchical.SubnetID, p2 abi.ChainEpoch) (*schema.Checkpoint, error) `perm:"read"`
 	}
@@ -3503,14 +3503,14 @@ func (s *HierarchicalCnsStub) MineSubnet(p0 context.Context, p1 address.Address,
 	return ErrNotSupported
 }
 
-func (s *HierarchicalCnsStruct) SyncSubnet(p0 context.Context, p1 hierarchical.SubnetID) error {
+func (s *HierarchicalCnsStruct) SyncSubnet(p0 context.Context, p1 hierarchical.SubnetID, p2 bool) error {
 	if s.Internal.SyncSubnet == nil {
 		return ErrNotSupported
 	}
-	return s.Internal.SyncSubnet(p0, p1)
+	return s.Internal.SyncSubnet(p0, p1, p2)
 }
 
-func (s *HierarchicalCnsStub) SyncSubnet(p0 context.Context, p1 hierarchical.SubnetID) error {
+func (s *HierarchicalCnsStub) SyncSubnet(p0 context.Context, p1 hierarchical.SubnetID, p2 bool) error {
 	return ErrNotSupported
 }
 

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -571,6 +571,8 @@ type HierarchicalCnsStruct struct {
 
 		MineSubnet func(p0 context.Context, p1 address.Address, p2 hierarchical.SubnetID, p3 bool) error `perm:"write"`
 
+		SyncSubnet func(p0 context.Context, p1 hierarchical.SubnetID) error `perm:"write"`
+
 		ValidateCheckpoint func(p0 context.Context, p1 hierarchical.SubnetID, p2 abi.ChainEpoch) (*schema.Checkpoint, error) `perm:"read"`
 	}
 }
@@ -3498,6 +3500,17 @@ func (s *HierarchicalCnsStruct) MineSubnet(p0 context.Context, p1 address.Addres
 }
 
 func (s *HierarchicalCnsStub) MineSubnet(p0 context.Context, p1 address.Address, p2 hierarchical.SubnetID, p3 bool) error {
+	return ErrNotSupported
+}
+
+func (s *HierarchicalCnsStruct) SyncSubnet(p0 context.Context, p1 hierarchical.SubnetID) error {
+	if s.Internal.SyncSubnet == nil {
+		return ErrNotSupported
+	}
+	return s.Internal.SyncSubnet(p0, p1)
+}
+
+func (s *HierarchicalCnsStub) SyncSubnet(p0 context.Context, p1 hierarchical.SubnetID) error {
 	return ErrNotSupported
 }
 

--- a/api/v0api/v0mocks/mock_full.go
+++ b/api/v0api/v0mocks/mock_full.go
@@ -2995,17 +2995,17 @@ func (mr *MockFullNodeMockRecorder) SyncSubmitBlock(arg0, arg1 interface{}) *gom
 }
 
 // SyncSubnet mocks base method.
-func (m *MockFullNode) SyncSubnet(arg0 context.Context, arg1 hierarchical.SubnetID) error {
+func (m *MockFullNode) SyncSubnet(arg0 context.Context, arg1 hierarchical.SubnetID, arg2 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncSubnet", arg0, arg1)
+	ret := m.ctrl.Call(m, "SyncSubnet", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SyncSubnet indicates an expected call of SyncSubnet.
-func (mr *MockFullNodeMockRecorder) SyncSubnet(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFullNodeMockRecorder) SyncSubnet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubnet", reflect.TypeOf((*MockFullNode)(nil).SyncSubnet), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubnet", reflect.TypeOf((*MockFullNode)(nil).SyncSubnet), arg0, arg1, arg2)
 }
 
 // SyncUnmarkAllBad mocks base method.

--- a/api/v0api/v0mocks/mock_full.go
+++ b/api/v0api/v0mocks/mock_full.go
@@ -2994,6 +2994,20 @@ func (mr *MockFullNodeMockRecorder) SyncSubmitBlock(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubmitBlock", reflect.TypeOf((*MockFullNode)(nil).SyncSubmitBlock), arg0, arg1)
 }
 
+// SyncSubnet mocks base method.
+func (m *MockFullNode) SyncSubnet(arg0 context.Context, arg1 hierarchical.SubnetID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncSubnet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncSubnet indicates an expected call of SyncSubnet.
+func (mr *MockFullNodeMockRecorder) SyncSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncSubnet", reflect.TypeOf((*MockFullNode)(nil).SyncSubnet), arg0, arg1)
+}
+
 // SyncUnmarkAllBad mocks base method.
 func (m *MockFullNode) SyncUnmarkAllBad(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/chain/consensus/hierarchical/subnet/manager/manager.go
+++ b/chain/consensus/hierarchical/subnet/manager/manager.go
@@ -470,7 +470,7 @@ func (s *SubnetMgr) SyncSubnet(ctx context.Context, id hierarchical.SubnetID, st
 
 // stopSyncSubnet stops syncing from a subnet
 func (s *SubnetMgr) stopSyncSubnet(ctx context.Context, id hierarchical.SubnetID) error {
-	if sh, _ := s.getSubnet(id); s != nil {
+	if sh, _ := s.getSubnet(id); sh != nil {
 		delete(s.subnets, id)
 		return sh.Close(ctx)
 	}
@@ -567,7 +567,7 @@ func (s *SubnetMgr) LeaveSubnet(
 
 	// See if we are already syncing with that chain. If this
 	// is the case we can remove the subnet
-	if sh, _ := s.getSubnet(id); s != nil {
+	if sh, _ := s.getSubnet(id); sh != nil {
 		log.Infow("Stop syncing with subnet", "subnetID", id)
 		delete(s.subnets, id)
 		return msg, sh.Close(ctx)

--- a/cmd/eudico/subnet.go
+++ b/cmd/eudico/subnet.go
@@ -243,6 +243,10 @@ var syncCmd = &cli.Command{
 			Usage: "specify the id of the subnet to sync with",
 			Value: hierarchical.RootSubnet.String(),
 		},
+		&cli.BoolFlag{
+			Name:  "stop",
+			Usage: "use this flag to determine if you want to start or stop mining",
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 
@@ -262,12 +266,11 @@ var syncCmd = &cli.Command{
 		if cctx.String("subnet") == hierarchical.RootSubnet.String() {
 			return xerrors.Errorf("no valid subnet so sync with specified")
 		}
-
-		err = api.SyncSubnet(ctx, hierarchical.SubnetID(subnet))
+		err = api.SyncSubnet(ctx, hierarchical.SubnetID(subnet), cctx.Bool("stop"))
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cctx.App.Writer, "Successfully syncing with subnet %s \n", subnet)
+		fmt.Fprintf(cctx.App.Writer, "Successfully started/stopped syncing with subnet %s \n", subnet)
 		return nil
 	},
 }
@@ -288,7 +291,7 @@ var mineCmd = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "stop",
-			Usage: "use this flag to determine if you want to start or stop mining",
+			Usage: "use this flag to stop mining a subnet",
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/node/impl/hierarchical/subnet.go
+++ b/node/impl/hierarchical/subnet.go
@@ -37,8 +37,8 @@ func (a *HierarchicalAPI) JoinSubnet(ctx context.Context, wallet address.Address
 	return a.Sub.JoinSubnet(ctx, wallet, value, id)
 }
 
-func (a *HierarchicalAPI) SyncSubnet(ctx context.Context, id hierarchical.SubnetID) error {
-	return a.Sub.SyncSubnet(ctx, id)
+func (a *HierarchicalAPI) SyncSubnet(ctx context.Context, id hierarchical.SubnetID, stop bool) error {
+	return a.Sub.SyncSubnet(ctx, id, stop)
 }
 
 func (a *HierarchicalAPI) MineSubnet(ctx context.Context, wallet address.Address,

--- a/node/impl/hierarchical/subnet.go
+++ b/node/impl/hierarchical/subnet.go
@@ -37,6 +37,10 @@ func (a *HierarchicalAPI) JoinSubnet(ctx context.Context, wallet address.Address
 	return a.Sub.JoinSubnet(ctx, wallet, value, id)
 }
 
+func (a *HierarchicalAPI) SyncSubnet(ctx context.Context, id hierarchical.SubnetID) error {
+	return a.Sub.SyncSubnet(ctx, id)
+}
+
 func (a *HierarchicalAPI) MineSubnet(ctx context.Context, wallet address.Address,
 	id hierarchical.SubnetID, stop bool) error {
 	return a.Sub.MineSubnet(ctx, wallet, id, stop)


### PR DESCRIPTION
Before this users could only start syncing with a subnet when they added collateral. Users may want to sync with a subnet even if they haven't added collateral and they are going to mine in it. They may still want to sync with the chain to validate the results of their transactions (in the future we may consider implementing light clients for subnets). 