### PR TITLE
Generalized cross-message types towards arbitrary cross-msgs

### DIFF
--- a/chain/consensus/actors/reward/reward_test.go
+++ b/chain/consensus/actors/reward/reward_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	actors "github.com/filecoin-project/lotus/chain/consensus/actors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/lotus/chain/consensus/actors/reward"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical"
 	"github.com/filecoin-project/specs-actors/v6/actors/builtin"
 	"github.com/filecoin-project/specs-actors/v6/support/mock"
 	tutil "github.com/filecoin-project/specs-actors/v6/support/testing"
@@ -85,11 +87,13 @@ func TestExternalFunding(t *testing.T) {
 	rt.SetBalance(abi.NewTokenAmount(1e18))
 	value := abi.NewTokenAmount(1)
 	params := &reward.FundingParams{Addr: addr, Value: value}
-	rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
+	rt.SetCaller(hierarchical.SubnetCoordActorAddr, actors.SubnetCoordActorCodeID)
+	rt.ExpectValidateCallerAddr(hierarchical.SubnetCoordActorAddr)
 	rt.ExpectSend(addr, builtin.MethodSend, nil, value, nil, 0)
 	rt.Call(actor.ExternalFunding, params)
 	rt.Verify()
 }
+
 func TestAwardBlockReward(t *testing.T) {
 	actor := rewardHarness{reward.Actor{}, t}
 	winner := tutil.NewIDAddr(t, 1000)

--- a/chain/consensus/common/crossmsg.go
+++ b/chain/consensus/common/crossmsg.go
@@ -145,7 +145,7 @@ func ApplyCrossMsg(ctx context.Context, vmi *vm.VM, submgr subnet.SubnetMgr,
 	case hierarchical.TopDown:
 		return applyTopDownMsg(ctx, vmi, submgr, em, msg, ts)
 	case hierarchical.BottomUp:
-		// Release messages can be applied right-away, without
+		// Bottomup messages can be applied right-away, without
 		// any pre-processing.
 		return applyMsg(ctx, vmi, em, msg, ts)
 	}

--- a/chain/consensus/common/crossmsg.go
+++ b/chain/consensus/common/crossmsg.go
@@ -75,7 +75,7 @@ func checkBottomUpMsg(ctx context.Context, r *resolver.Resolver, snstore blockad
 		return xerrors.Errorf("context timeout")
 	case err := <-out:
 		if err != nil {
-			return xerrors.Errorf("error fully resolving messages", err)
+			return xerrors.Errorf("error fully resolving messages: %s", err)
 		}
 	}
 

--- a/chain/consensus/common/crossmsg.go
+++ b/chain/consensus/common/crossmsg.go
@@ -153,7 +153,7 @@ func ApplyCrossMsg(ctx context.Context, vmi *vm.VM, submgr subnet.SubnetMgr,
 func applyMsg(ctx context.Context, vmi *vm.VM, em stmgr.ExecMonitor,
 	msg *types.Message, ts *types.TipSet) error {
 	// Serialize params
-	params := &sca.MsgParams{
+	params := &sca.CrossMsgParams{
 		Msg: *msg,
 	}
 	serparams, aerr := actors.SerializeParams(params)

--- a/chain/consensus/common/utils.go
+++ b/chain/consensus/common/utils.go
@@ -18,10 +18,7 @@ func (ma MessageArray) Len() int {
 }
 
 func (ma MessageArray) Less(i, j int) bool {
-	if ma[i].Nonce <= ma[j].Nonce {
-		return true
-	}
-	return false
+	return ma[i].Nonce <= ma[j].Nonce
 }
 
 func (ma MessageArray) Swap(i, j int) {
@@ -55,6 +52,9 @@ func recoverOriginalNonce(r *resolver.Resolver, n uint64, sca *sca.SCAState,
 	}
 	c, _ := meta.Cid()
 	orig, _, err := r.ResolveCrossMsgs(c, address.SubnetID(meta.From))
+	if err != nil {
+		return []*types.Message{}, xerrors.Errorf("error resolving cross-msgs: %w", err)
+	}
 
 	for _, o := range orig {
 		for _, m := range msg {

--- a/chain/consensus/hierarchical/actors/sca/cbor_gen.go
+++ b/chain/consensus/hierarchical/actors/sca/cbor_gen.go
@@ -951,14 +951,14 @@ func (t *MetaTag) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufMsgParams = []byte{129}
+var lengthBufCrossMsgParams = []byte{129}
 
-func (t *MsgParams) MarshalCBOR(w io.Writer) error {
+func (t *CrossMsgParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufMsgParams); err != nil {
+	if _, err := w.Write(lengthBufCrossMsgParams); err != nil {
 		return err
 	}
 
@@ -969,8 +969,8 @@ func (t *MsgParams) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *MsgParams) UnmarshalCBOR(r io.Reader) error {
-	*t = MsgParams{}
+func (t *CrossMsgParams) UnmarshalCBOR(r io.Reader) error {
+	*t = CrossMsgParams{}
 
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)

--- a/chain/consensus/hierarchical/actors/sca/cbor_gen.go
+++ b/chain/consensus/hierarchical/actors/sca/cbor_gen.go
@@ -951,14 +951,14 @@ func (t *MetaTag) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufApplyParams = []byte{129}
+var lengthBufMsgParams = []byte{129}
 
-func (t *ApplyParams) MarshalCBOR(w io.Writer) error {
+func (t *MsgParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufApplyParams); err != nil {
+	if _, err := w.Write(lengthBufMsgParams); err != nil {
 		return err
 	}
 
@@ -969,8 +969,8 @@ func (t *ApplyParams) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *ApplyParams) UnmarshalCBOR(r io.Reader) error {
-	*t = ApplyParams{}
+func (t *MsgParams) UnmarshalCBOR(r io.Reader) error {
+	*t = MsgParams{}
 
 	br := cbg.GetPeeker(r)
 	scratch := make([]byte, 8)

--- a/chain/consensus/hierarchical/actors/sca/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -16,7 +16,7 @@ func main() {
 		actor.SubnetIDParam{},
 		actor.CrossMsgs{},
 		actor.MetaTag{},
-		actor.MsgParams{},
+		actor.CrossMsgParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/chain/consensus/hierarchical/actors/sca/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -16,7 +16,7 @@ func main() {
 		actor.SubnetIDParam{},
 		actor.CrossMsgs{},
 		actor.MetaTag{},
-		actor.ApplyParams{},
+		actor.MsgParams{},
 	); err != nil {
 		panic(err)
 	}

--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -30,8 +30,9 @@ var Methods = struct {
 	CommitChildCheckpoint abi.MethodNum
 	Fund                  abi.MethodNum
 	Release               abi.MethodNum
+	SendCross             abi.MethodNum
 	ApplyMessage          abi.MethodNum
-}{builtin0.MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9}
+}{builtin0.MethodConstructor, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 
 type SubnetIDParam struct {
 	ID string
@@ -49,7 +50,8 @@ func (a SubnetCoordActor) Exports() []interface{} {
 		6:                         a.CommitChildCheckpoint,
 		7:                         a.Fund,
 		8:                         a.Release,
-		9:                         a.ApplyMessage,
+		9:                         a.SendCross,
+		10:                        a.ApplyMessage,
 	}
 }
 
@@ -451,8 +453,47 @@ func SecpBLSAddr(rt runtime.Runtime, raw address.Address) address.Address {
 	return pubkey
 }
 
-// ApplyParams determines the cross message to apply.
-type ApplyParams struct {
+// SendCross sends an arbitrary cross-message to other subnet in the hierarchy.
+//
+// If the message includes any funds they need to be burnt (like in Release)
+// before being propagated to the
+func (a SubnetCoordActor) SendCross(rt runtime.Runtime, param *MsgParams) *abi.EmptyValue {
+	panic("not implemented yet")
+	/*
+		// Create the message
+
+		// Only account actors can release funds from a subnet (for now).
+		rt.ValidateImmediateCallerType(builtin.AccountActorCodeID)
+
+		// Check if the transaction includes funds
+		value := rt.ValueReceived()
+		if value.LessThanEqual(big.NewInt(0)) {
+			rt.Abortf(exitcode.ErrIllegalArgument, "no funds included in transaction")
+		}
+
+		// Burn from subnet funds being sent.
+		code := rt.Send(builtin.BurntFundsActorAddr, builtin.MethodSend, nil, rt.ValueReceived(), &builtin.Discard{})
+		if !code.IsSuccess() {
+			rt.Abortf(exitcode.ErrIllegalState,
+				"failed to send release funds to the burnt funds actor, code: %v", code)
+		}
+
+		// Get SECP/BLS publickey to know the specific actor ID in the target subnet to
+		// whom the funds need to be sent.
+		// Funds are sent to the ID that controls the actor account in the destination subnet.
+		secpAddr := SecpBLSAddr(rt, rt.Caller())
+
+		var st SCAState
+		rt.StateTransaction(&st, func() {
+			// Create releaseMsg and include in currentwindow checkpoint
+			st.releaseMsg(rt, value, secpAddr)
+		})
+		return nil
+	*/
+}
+
+// MsgParams determines the cross message to apply.
+type MsgParams struct {
 	Msg types.Message
 }
 
@@ -464,19 +505,19 @@ type ApplyParams struct {
 // - Determines the type of cross-message.
 // - Performs the corresponding state changes.
 // - And updated the latest nonce applied for future checks.
-func (a SubnetCoordActor) ApplyMessage(rt runtime.Runtime, params *ApplyParams) *abi.EmptyValue {
+func (a SubnetCoordActor) ApplyMessage(rt runtime.Runtime, params *MsgParams) *abi.EmptyValue {
 	// Only system actor can trigger this function.
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 
 	switch hierarchical.GetMsgType(&params.Msg) {
-	case hierarchical.Fund:
+	case hierarchical.TopDown:
 		// Fund messages are applied in the SCA of the subnet to which
 		// the TopDown message is directed.
-		applyFund(rt, params.Msg)
-	case hierarchical.Release:
-		applyRelease(rt, params.Msg)
-	case hierarchical.Cross:
-		rt.Abortf(exitcode.ErrIllegalArgument, "Not implemented yet")
+		applyTopDown(rt, params.Msg)
+	case hierarchical.BottomUp:
+		applyBottomUp(rt, params.Msg)
+	default:
+		rt.Abortf(exitcode.ErrIllegalArgument, "Wrong cross-message type")
 	}
 	return nil
 }

--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -456,7 +456,8 @@ func SecpBLSAddr(rt runtime.Runtime, raw address.Address) address.Address {
 // SendCross sends an arbitrary cross-message to other subnet in the hierarchy.
 //
 // If the message includes any funds they need to be burnt (like in Release)
-// before being propagated to the
+// before being propagated to the corresponding subnet.
+// The circulating supply in each subnet needs to be updated as the message passes through them.
 func (a SubnetCoordActor) SendCross(rt runtime.Runtime, param *MsgParams) *abi.EmptyValue {
 	panic("not implemented yet")
 	/*

--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -463,7 +463,7 @@ func SecpBLSAddr(rt runtime.Runtime, raw address.Address) address.Address {
 // If the message includes any funds they need to be burnt (like in Release)
 // before being propagated to the corresponding subnet.
 // The circulating supply in each subnet needs to be updated as the message passes through them.
-func (a SubnetCoordActor) SendCross(rt runtime.Runtime, param *MsgParams) *abi.EmptyValue {
+func (a SubnetCoordActor) SendCross(rt runtime.Runtime, param *CrossMsgParams) *abi.EmptyValue {
 	// Any account in the subnet is allowed to trigger a cross message.
 	rt.ValidateImmediateCallerAcceptAny()
 
@@ -499,8 +499,8 @@ func (a SubnetCoordActor) SendCross(rt runtime.Runtime, param *MsgParams) *abi.E
 	*/
 }
 
-// MsgParams determines the cross message to apply.
-type MsgParams struct {
+// CrossMsgParams determines the cross message to apply.
+type CrossMsgParams struct {
 	Msg types.Message
 }
 
@@ -512,7 +512,7 @@ type MsgParams struct {
 // - Determines the type of cross-message.
 // - Performs the corresponding state changes.
 // - And updated the latest nonce applied for future checks.
-func (a SubnetCoordActor) ApplyMessage(rt runtime.Runtime, params *MsgParams) *abi.EmptyValue {
+func (a SubnetCoordActor) ApplyMessage(rt runtime.Runtime, params *CrossMsgParams) *abi.EmptyValue {
 	// Only system actor can trigger this function.
 	rt.ValidateImmediateCallerIs(builtin.SystemActorAddr)
 

--- a/chain/consensus/hierarchical/actors/sca/sca_cross.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_cross.go
@@ -133,6 +133,7 @@ func (st *SCAState) releaseMsg(rt runtime.Runtime, value big.Int, to address.Add
 		From:       from,
 		Value:      value,
 		Nonce:      st.Nonce,
+		Method:     builtin.MethodSend,
 		GasLimit:   1 << 30, // This is will be applied as an implicit msg, add enough gas
 		GasFeeCap:  ltypes.NewInt(0),
 		GasPremium: ltypes.NewInt(0),

--- a/chain/consensus/hierarchical/actors/sca/sca_subnet.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_subnet.go
@@ -90,6 +90,7 @@ func (sh *Subnet) addFundMsg(rt runtime.Runtime, value big.Int) {
 		To:         to,
 		From:       from,
 		Value:      value,
+		Method:     builtin.MethodSend,
 		Nonce:      sh.Nonce,
 		GasLimit:   1 << 30, // This is will be applied as an implicit msg, add enough gas
 		GasFeeCap:  ltypes.NewInt(0),

--- a/chain/consensus/hierarchical/actors/sca/sca_subnet.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_subnet.go
@@ -69,18 +69,12 @@ func (sh *Subnet) freezeFunds(rt runtime.Runtime, source address.Address, value 
 	sh.CircSupply = big.Add(sh.CircSupply, value)
 }
 
-func (sh *Subnet) addFundMsg(rt runtime.Runtime, value big.Int) {
-	// Source
-	// NOTE: We are including here the ID address from the source, but the user
-	// may have a completely different ID address in the subnet. Nodes will have
-	// to translate this ID address to the right SECP/BLS address that owns the
-	// account
-	source := rt.Caller()
+func (sh *Subnet) addFundMsg(rt runtime.Runtime, secp address.Address, value big.Int) {
 
 	// Transform To and From to HAddresses
-	to, err := address.NewHAddress(sh.ID, source)
+	to, err := address.NewHAddress(sh.ID, secp)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create HAddress")
-	from, err := address.NewHAddress(sh.ID.Parent(), source)
+	from, err := address.NewHAddress(sh.ID.Parent(), secp)
 	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to create HAddress")
 
 	// Build message.

--- a/chain/consensus/hierarchical/actors/sca/sca_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_test.go
@@ -838,7 +838,7 @@ func TestApplyMsg(t *testing.T) {
 
 func (h *shActorHarness) applyFundMsg(rt *mock.Runtime, addr address.Address, value big.Int, nonce uint64, abort bool) {
 	rt.SetCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
-	params := &actor.MsgParams{
+	params := &actor.CrossMsgParams{
 		Msg: ltypes.Message{
 			To:         addr,
 			From:       addr,
@@ -874,7 +874,7 @@ func (h *shActorHarness) applyReleaseMsg(rt *mock.Runtime, addr address.Address,
 	rt.SetBalance(value)
 	from, err := address.NewHAddress(h.sn, builtin.BurntFundsActorAddr)
 	require.NoError(h.t, err)
-	params := &actor.MsgParams{
+	params := &actor.CrossMsgParams{
 		Msg: ltypes.Message{
 			To:         addr,
 			From:       from,

--- a/chain/consensus/hierarchical/subnet/resolver/resolver_test.go
+++ b/chain/consensus/hierarchical/subnet/resolver/resolver_test.go
@@ -110,8 +110,7 @@ func TestWaitResolve(t *testing.T) {
 		err = r.setLocal(c, out)
 		require.NoError(t, err)
 	}()
-	select {
-	case err := <-found:
-		require.NoError(t, err)
-	}
+
+	err = <-found
+	require.NoError(t, err)
 }

--- a/chain/consensus/hierarchical/types.go
+++ b/chain/consensus/hierarchical/types.go
@@ -73,9 +73,7 @@ func CommonParent(from, to address.SubnetID) (address.SubnetID, int) {
 	s1 := strings.Split(from.String(), "/")
 	s2 := strings.Split(to.String(), "/")
 	if len(s1) < len(s2) {
-		a := s1
-		s1 = s2
-		s2 = a
+		s1, s2 = s2, s1
 	}
 	out := "/"
 	l := 0
@@ -90,7 +88,7 @@ func CommonParent(from, to address.SubnetID) (address.SubnetID, int) {
 	return address.SubnetID(out), l
 }
 
-func isParent(curr, from, to address.SubnetID) bool {
+func IsParent(curr, from, to address.SubnetID) bool {
 	parent, _ := CommonParent(from, to)
 	return parent == curr
 }
@@ -98,8 +96,5 @@ func isParent(curr, from, to address.SubnetID) bool {
 func IsBottomUp(from, to address.SubnetID) bool {
 	_, l := CommonParent(from, to)
 	sfrom := strings.Split(from.String(), "/")
-	if len(sfrom)-1 <= l {
-		return false
-	}
-	return true
+	return len(sfrom)-1 > l
 }

--- a/chain/consensus/hierarchical/types_test.go
+++ b/chain/consensus/hierarchical/types_test.go
@@ -1,0 +1,25 @@
+package hierarchical_test
+
+import (
+	"testing"
+
+	address "github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubnetOps(t *testing.T) {
+	testParentAndBottomUp(t, "/root/a", "/root/a/b", "/root/a", 2, false)
+	testParentAndBottomUp(t, "/root/c/a", "/root/a/b", "/root", 1, true)
+	testParentAndBottomUp(t, "/root/c/a/d", "/root/c/a/e", "/root/c/a", 3, true)
+	testParentAndBottomUp(t, "/root/c/a", "/root/c/b", "/root/c", 2, true)
+}
+
+func testParentAndBottomUp(t *testing.T, from, to, parent string, exl int, bottomup bool) {
+	p, l := hierarchical.CommonParent(
+		address.SubnetID(from), address.SubnetID(to))
+	require.Equal(t, p, address.SubnetID(parent))
+	require.Equal(t, exl, l)
+	require.Equal(t, hierarchical.IsBottomUp(
+		address.SubnetID(from), address.SubnetID(to)), bottomup)
+}


### PR DESCRIPTION
- Switched `Fund` and `Release` cross-message types to `TopDown` and `BottomUp` respectively.
- Generalized the application of cross messages.
- Use of f04 addresses in messages to determine message type.