### PR TITLE
Support for arbitrary params in cross-net messages

### DIFF
--- a/chain/consensus/hierarchical/actors/sca/sca_apply.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_apply.go
@@ -64,10 +64,8 @@ func applyTopDown(rt runtime.Runtime, msg types.Message) {
 		})
 	} else {
 		// Send the cross-message
-		// FIXME: We are currently discarding the output, this will change once we
-		// support calling arbitrary actors. And we don't support params. We'll need a way
-		// to support arbitrary calls.
-		code = rt.Send(rto, msg.Method, nil, msg.Value, &builtin.Discard{})
+		// FIXME: Should we not discard the output for any reason?
+		code = rt.SendWithSerializedParams(rto, msg.Method, msg.Params, msg.Value, &builtin.Discard{})
 		if !code.IsSuccess() {
 			noop(rt, code)
 		}
@@ -97,9 +95,8 @@ func applyBottomUp(rt runtime.Runtime, msg types.Message) {
 
 	if sto == st.NetworkName {
 		// Release funds to the destination address if it is directed to the current network.
-		// FIXME: We currently don't support sending messages with arbitrary params. We should
-		// support this.
-		code := rt.Send(rto, msg.Method, nil, msg.Value, &builtin.Discard{})
+		// FIXME: Should we not discard the output for any reason?
+		code := rt.SendWithSerializedParams(rto, msg.Method, msg.Params, msg.Value, &builtin.Discard{})
 		if !code.IsSuccess() {
 			noop(rt, code)
 		}

--- a/chain/vm/runtime.go
+++ b/chain/vm/runtime.go
@@ -374,9 +374,6 @@ func (rt *Runtime) CurrEpoch() abi.ChainEpoch {
 }
 
 func (rt *Runtime) Send(to address.Address, method abi.MethodNum, m cbor.Marshaler, value abi.TokenAmount, out cbor.Er) exitcode.ExitCode {
-	if !rt.allowInternal {
-		rt.Abortf(exitcode.SysErrorIllegalActor, "runtime.Send() is currently disallowed")
-	}
 	var params []byte
 	if m != nil {
 		buf := new(bytes.Buffer)
@@ -384,6 +381,13 @@ func (rt *Runtime) Send(to address.Address, method abi.MethodNum, m cbor.Marshal
 			rt.Abortf(exitcode.ErrSerialization, "failed to marshal input parameters: %s", err)
 		}
 		params = buf.Bytes()
+	}
+	return rt.SendWithSerializedParams(to, method, params, value, out)
+}
+
+func (rt *Runtime) SendWithSerializedParams(to address.Address, method abi.MethodNum, params []byte, value abi.TokenAmount, out cbor.Er) exitcode.ExitCode {
+	if !rt.allowInternal {
+		rt.Abortf(exitcode.SysErrorIllegalActor, "runtime.Send() is currently disallowed")
 	}
 
 	ret, err := rt.internalSend(rt.Receiver(), to, method, value, params)

--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,9 @@ require (
 
 // FIXME: Replacing with a fork to upgrade go-ipld-cbor and support to network v15 and v7 while keeping new actors
 // in the eudico repo.
-replace github.com/filecoin-project/specs-actors/v7 => github.com/adlrocha/specs-actors/v7 v7.0.0-rc1.0.20220204105221-abb2f8c8a27a
+// In this fork we also include a SendWithSerializedParams required to forward messages with already serialized
+// params from an actor.
+replace github.com/filecoin-project/specs-actors/v7 => github.com/adlrocha/specs-actors/v7 v7.0.0-rc1.0.20220215102846-08bb2fde502a
 
 // FIXME: Replacing with a fork that includes support to hierarchical consensus addresses.
 replace github.com/filecoin-project/go-address => github.com/adlrocha/go-address v0.0.7-0.20220201161333-9140b209222d

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/adlrocha/go-address v0.0.7-0.20220201161333-9140b209222d h1:49cRLnRjRE3YO4NsdFhkVhz2Y/Zv5a/V7a9iFZW76/E=
 github.com/adlrocha/go-address v0.0.7-0.20220201161333-9140b209222d/go.mod h1:7B0/5DA13n6nHkB8bbGx1gWzG/dbTsZ0fgOJVGsM3TE=
-github.com/adlrocha/specs-actors/v7 v7.0.0-rc1.0.20220204105221-abb2f8c8a27a h1:KBbcrHlNNqTPQgg+Ugl8FGO1AqIXLYZe+MHd1FdHZSI=
-github.com/adlrocha/specs-actors/v7 v7.0.0-rc1.0.20220204105221-abb2f8c8a27a/go.mod h1:QQisUhgXrjKFA1u8d3k4MDL0A04sDUQrUTJUsLRJDBk=
+github.com/adlrocha/specs-actors/v7 v7.0.0-rc1.0.20220215102846-08bb2fde502a h1:P3KHHAOD20pEI2MC8SYTRqrfSrBq6BSink8ROQDhjGE=
+github.com/adlrocha/specs-actors/v7 v7.0.0-rc1.0.20220215102846-08bb2fde502a/go.mod h1:QQisUhgXrjKFA1u8d3k4MDL0A04sDUQrUTJUsLRJDBk=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=


### PR DESCRIPTION
This PR includes a `SendWithSerializedParams` in the runtime interface (and the vm implementation) to support forwarding cross-net messages with already serialized params to the right destination.

_Note: this required a fork of `filecoin-project/specs-actors` with the new runtime interface._

