### PR TITLE
Fix README and FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,18 +1,18 @@
 # Eudico FAQ
 _Note: The aim of these FAQs is to get you started fast with Eudico so you can spawn a test network and start contributing to the code in no time. For more in depth documentation or further information about how to perform other actions go to the [Lotus documentation](https://lotus.filecoin.io/docs/set-up/about/), or refer to the base code. Eudico is a fork of Lotus, which means that "almost" everything that works in Lotus should work in Eudico out-of-the-box._
 
-**Q: How to import a wallet?**
+## Q: How to import a wallet?
 
 **A:** Generate a key:
 ```
-./lotus-keygen -t spec256k1
+./lotus-keygen -t secp256k1
 ```
 Import it (as default if needed):
 ```
 ./eudico wallet import –-as-default –-format=json-lotus $file
 ```
 
-**Q: How to generate the cbor files when creating a new actor?**
+## Q: How to generate the cbor files when creating a new actor?
 
 **A:** The Cbor library is used to help with marshalling and unmarshalling.
 In the same folder where your `$actorName_actor.go` and `$actorName_state.go` files are defined, create a `gen` folder with a `gen.go` file that looks like [this](https://github.com/filecoin-project/eudico/blob/eudico/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -26,43 +26,43 @@ func (t *$YourStruct) MarshalCBOR(w io.Writer) error { return nil }
 Run  `go run gen.go`. 
 
 
-**Q: How do you send a transaction directly from the code?**
+## Q: How do you send a transaction directly from the code?
 **A:** By using the `api-MpoolPushMessage.` See how to use it [here](https://github.com/filecoin-project/eudico/blob/113829e7fc115daac08ea0217170baddcb7788ba/chain/consensus/hierarchical/subnet/manager/manager.go#L375-L391).
 
-**Q: How can a built-in actor be initialize?
-A:** You can see an example of how is done for the SCA in [this piece of code](https://github.com/filecoin-project/eudico/blob/113829e7fc115daac08ea0217170baddcb7788ba/chain/consensus/hierarchical/actors/subnet/genesis.go#L131).
+## Q: How can a built-in actor be initialize?
+**A:** You can see an example of how is done for the SCA in [this piece of code](https://github.com/filecoin-project/eudico/blob/113829e7fc115daac08ea0217170baddcb7788ba/chain/consensus/hierarchical/actors/subnet/genesis.go#L131).
 
-**Q: How can I run an eudico network with a specific consensus protocol?
-A:** Use the following commands:
+## Q: How can I run an eudico network with a specific consensus protocol?
+**A:** Use the following commands:
 
 Run a network:
  ```
- ./eudico tspow genesis $ADDR gen.gen
- ./eudico tspow daemon --genesis=gen.gen
+ ./eudico delegated genesis $ADDR gen.gen
+ ./eudico delegated daemon --genesis=gen.gen
  ```
  Run a miner:
  ```
  ./eudico wallet import --format=json-lotus $ADDR
- ./eudico tspow miner
+ ./eudico delegated miner
  ```
  
-**Q: How can I run two eudico peers on the same host?
-A:** Use a different `EUDICO_PATH` variable and `api` argument for each path.
+## Q: How can I run two eudico peers on the same host?
+**A:** Use a different `EUDICO_PATH` variable and `api` argument for each path.
 
 Terminal 1:
 ```
 export EUDICO_PATH="~/.eudico1/"
-./eudico tspow daemon --genesis=gen.gen --api=1234
+./eudico delegated daemon --genesis=gen.gen --api=1234
 ```
 
 Terminal 2:
 ```
 export EUDICO_PATH="~/.eudico2/"
-./eudico tspow daemon --genesis=gen.gen --api=1235
+./eudico delegated daemon --genesis=gen.gen --api=1235
 ```
 
-**Q: How can two two eudico clients be connected with each other?
-A:** Suppose you have two eudico clients A and B. Run the following commands:
+## Q: How can two two eudico clients be connected with each other?
+**A:** Suppose you have two eudico clients A and B. Run the following commands:
 
 On client A run the command below to output the target's libp2p address, `ADDR_A` 
 ```


### PR DESCRIPTION
Parts of the README and FAQ were improperly copy-pasted from their
Lotus counterparts and the commands were not working.
Now a new user should be able to run a dev network on the local
machine by following the guide in the README.