### PR TITLE
Added subnet actor interface

### DIFF
--- a/chain/consensus/hierarchical/actors/subnet/iface.go
+++ b/chain/consensus/hierarchical/actors/subnet/iface.go
@@ -1,0 +1,16 @@
+package subnet
+
+import (
+	abi "github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
+	"github.com/filecoin-project/specs-actors/v7/actors/runtime"
+)
+
+// SubnetIface defines the minimum interface that needs to be implemented by subnet
+// actors
+type SubnetIface interface {
+	Join(rt runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue
+	Leave(rt runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue
+	SubmitCheckpoint(rt runtime.Runtime, params *sca.CheckpointParams) *abi.EmptyValue
+	Kill(rt runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue
+}

--- a/chain/consensus/hierarchical/actors/subnet/subnet_actor.go
+++ b/chain/consensus/hierarchical/actors/subnet/subnet_actor.go
@@ -24,6 +24,7 @@ import (
 )
 
 var _ runtime.VMActor = SubnetActor{}
+var _ SubnetIface = SubnetActor{}
 
 var log = logging.Logger("subnet-actor")
 


### PR DESCRIPTION
This is more of a cosmetic PR. In the spec for hierarchical consensus we keep referring to the "subnet actor interface", but it wasn't explicitly defined in the code. This PR adds a placeholder for it in the reference implementation of the subnet actor. It may change in the future.