### PR TITLE
Commands to manage atomic executions between subnets

### DIFF
--- a/api/api_hierarchical.go
+++ b/api/api_hierarchical.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/checkpoints/schema"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
@@ -26,4 +27,8 @@ type HierarchicalCns interface {
 	CrossMsgResolve(ctx context.Context, id address.SubnetID, c cid.Cid, from address.SubnetID) ([]types.Message, error)   // perm:read
 	LockState(ctx context.Context, wallet address.Address, actor address.Address, subnet address.SubnetID,
 		method abi.MethodNum) (cid.Cid, error) // perm:write
+	InitAtomicExec(ctx context.Context, wallet address.Address, inputs map[string]sca.LockedState, msgs []types.Message) (cid.Cid, error) // perm:write
+	ListAtomicExecs(ctx context.Context, id address.SubnetID, addr address.Address) ([]*sca.AtomicExec, error)                            // perm:read
+	ComputeAndSubmitExec(ctx context.Context, wallet address.Address, id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error)        // perm:write
+	AbortAtomicExec(ctx context.Context, wallet address.Address, id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error)             // perm:write
 }

--- a/api/api_hierarchical.go
+++ b/api/api_hierarchical.go
@@ -24,4 +24,6 @@ type HierarchicalCns interface {
 	FundSubnet(ctx context.Context, wallet address.Address, id address.SubnetID, value abi.TokenAmount) (cid.Cid, error)   // perm:write
 	ReleaseFunds(ctx context.Context, wallet address.Address, id address.SubnetID, value abi.TokenAmount) (cid.Cid, error) // perm:write
 	CrossMsgResolve(ctx context.Context, id address.SubnetID, c cid.Cid, from address.SubnetID) ([]types.Message, error)   // perm:read
+	LockState(ctx context.Context, wallet address.Address, actor address.Address, subnet address.SubnetID,
+		method abi.MethodNum) (cid.Cid, error) // perm:write
 }

--- a/api/api_hierarchical.go
+++ b/api/api_hierarchical.go
@@ -27,8 +27,9 @@ type HierarchicalCns interface {
 	CrossMsgResolve(ctx context.Context, id address.SubnetID, c cid.Cid, from address.SubnetID) ([]types.Message, error)   // perm:read
 	LockState(ctx context.Context, wallet address.Address, actor address.Address, subnet address.SubnetID,
 		method abi.MethodNum) (cid.Cid, error) // perm:write
+	UnlockState(ctx context.Context, wallet address.Address, actor address.Address, subnet address.SubnetID, method abi.MethodNum) error  // perm:write
 	InitAtomicExec(ctx context.Context, wallet address.Address, inputs map[string]sca.LockedState, msgs []types.Message) (cid.Cid, error) // perm:write
-	ListAtomicExecs(ctx context.Context, id address.SubnetID, addr address.Address) ([]*sca.AtomicExec, error)                            // perm:read
+	ListAtomicExecs(ctx context.Context, id address.SubnetID, addr address.Address) ([]sca.AtomicExec, error)                             // perm:read
 	ComputeAndSubmitExec(ctx context.Context, wallet address.Address, id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error)        // perm:write
 	AbortAtomicExec(ctx context.Context, wallet address.Address, id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error)             // perm:write
 }

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -1132,10 +1132,10 @@ func (mr *MockFullNodeMockRecorder) LeaveSubnet(arg0, arg1, arg2 interface{}) *g
 }
 
 // ListAtomicExecs mocks base method.
-func (m *MockFullNode) ListAtomicExecs(arg0 context.Context, arg1 address.SubnetID, arg2 address.Address) ([]*sca.AtomicExec, error) {
+func (m *MockFullNode) ListAtomicExecs(arg0 context.Context, arg1 address.SubnetID, arg2 address.Address) ([]sca.AtomicExec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAtomicExecs", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*sca.AtomicExec)
+	ret0, _ := ret[0].([]sca.AtomicExec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3271,6 +3271,20 @@ func (m *MockFullNode) SyncValidateTipset(arg0 context.Context, arg1 types.TipSe
 func (mr *MockFullNodeMockRecorder) SyncValidateTipset(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncValidateTipset", reflect.TypeOf((*MockFullNode)(nil).SyncValidateTipset), arg0, arg1)
+}
+
+// UnlockState mocks base method.
+func (m *MockFullNode) UnlockState(arg0 context.Context, arg1, arg2 address.Address, arg3 address.SubnetID, arg4 abi.MethodNum) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnlockState", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnlockState indicates an expected call of UnlockState.
+func (mr *MockFullNodeMockRecorder) UnlockState(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockState", reflect.TypeOf((*MockFullNode)(nil).UnlockState), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ValidateCheckpoint mocks base method.

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -1100,6 +1100,21 @@ func (mr *MockFullNodeMockRecorder) ListCheckpoints(arg0, arg1, arg2 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCheckpoints", reflect.TypeOf((*MockFullNode)(nil).ListCheckpoints), arg0, arg1, arg2)
 }
 
+// LockState mocks base method.
+func (m *MockFullNode) LockState(arg0 context.Context, arg1, arg2 address.Address, arg3 address.SubnetID, arg4 abi.MethodNum) (cid.Cid, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LockState", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(cid.Cid)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LockState indicates an expected call of LockState.
+func (mr *MockFullNodeMockRecorder) LockState(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockState", reflect.TypeOf((*MockFullNode)(nil).LockState), arg0, arg1, arg2, arg3, arg4)
+}
+
 // LogAlerts mocks base method.
 func (m *MockFullNode) LogAlerts(arg0 context.Context) ([]alerting.Alert, error) {
 	m.ctrl.T.Helper()

--- a/api/mocks/mock_full.go
+++ b/api/mocks/mock_full.go
@@ -23,6 +23,7 @@ import (
 	api "github.com/filecoin-project/lotus/api"
 	apitypes "github.com/filecoin-project/lotus/api/types"
 	miner "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	sca "github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	schema "github.com/filecoin-project/lotus/chain/consensus/hierarchical/checkpoints/schema"
 	types "github.com/filecoin-project/lotus/chain/types"
 	alerting "github.com/filecoin-project/lotus/journal/alerting"
@@ -60,6 +61,21 @@ func NewMockFullNode(ctrl *gomock.Controller) *MockFullNode {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFullNode) EXPECT() *MockFullNodeMockRecorder {
 	return m.recorder
+}
+
+// AbortAtomicExec mocks base method.
+func (m *MockFullNode) AbortAtomicExec(arg0 context.Context, arg1 address.Address, arg2 address.SubnetID, arg3 cid.Cid) (sca.ExecStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AbortAtomicExec", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(sca.ExecStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AbortAtomicExec indicates an expected call of AbortAtomicExec.
+func (mr *MockFullNodeMockRecorder) AbortAtomicExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AbortAtomicExec", reflect.TypeOf((*MockFullNode)(nil).AbortAtomicExec), arg0, arg1, arg2, arg3)
 }
 
 // AddSubnet mocks base method.
@@ -891,6 +907,21 @@ func (mr *MockFullNodeMockRecorder) Closing(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Closing", reflect.TypeOf((*MockFullNode)(nil).Closing), arg0)
 }
 
+// ComputeAndSubmitExec mocks base method.
+func (m *MockFullNode) ComputeAndSubmitExec(arg0 context.Context, arg1 address.Address, arg2 address.SubnetID, arg3 cid.Cid) (sca.ExecStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ComputeAndSubmitExec", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(sca.ExecStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ComputeAndSubmitExec indicates an expected call of ComputeAndSubmitExec.
+func (mr *MockFullNodeMockRecorder) ComputeAndSubmitExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeAndSubmitExec", reflect.TypeOf((*MockFullNode)(nil).ComputeAndSubmitExec), arg0, arg1, arg2, arg3)
+}
+
 // CreateBackup mocks base method.
 func (m *MockFullNode) CreateBackup(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -1040,6 +1071,21 @@ func (mr *MockFullNodeMockRecorder) ID(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockFullNode)(nil).ID), arg0)
 }
 
+// InitAtomicExec mocks base method.
+func (m *MockFullNode) InitAtomicExec(arg0 context.Context, arg1 address.Address, arg2 map[string]sca.LockedState, arg3 []types.Message) (cid.Cid, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitAtomicExec", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(cid.Cid)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InitAtomicExec indicates an expected call of InitAtomicExec.
+func (mr *MockFullNodeMockRecorder) InitAtomicExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitAtomicExec", reflect.TypeOf((*MockFullNode)(nil).InitAtomicExec), arg0, arg1, arg2, arg3)
+}
+
 // JoinSubnet mocks base method.
 func (m *MockFullNode) JoinSubnet(arg0 context.Context, arg1 address.Address, arg2 big.Int, arg3 address.SubnetID) (cid.Cid, error) {
 	m.ctrl.T.Helper()
@@ -1083,6 +1129,21 @@ func (m *MockFullNode) LeaveSubnet(arg0 context.Context, arg1 address.Address, a
 func (mr *MockFullNodeMockRecorder) LeaveSubnet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveSubnet", reflect.TypeOf((*MockFullNode)(nil).LeaveSubnet), arg0, arg1, arg2)
+}
+
+// ListAtomicExecs mocks base method.
+func (m *MockFullNode) ListAtomicExecs(arg0 context.Context, arg1 address.SubnetID, arg2 address.Address) ([]*sca.AtomicExec, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAtomicExecs", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*sca.AtomicExec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAtomicExecs indicates an expected call of ListAtomicExecs.
+func (mr *MockFullNodeMockRecorder) ListAtomicExecs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAtomicExecs", reflect.TypeOf((*MockFullNode)(nil).ListAtomicExecs), arg0, arg1, arg2)
 }
 
 // ListCheckpoints mocks base method.

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -580,6 +580,8 @@ type HierarchicalCnsStruct struct {
 
 		ListCheckpoints func(p0 context.Context, p1 address.SubnetID, p2 int) ([]*schema.Checkpoint, error) `perm:"read"`
 
+		LockState func(p0 context.Context, p1 address.Address, p2 address.Address, p3 address.SubnetID, p4 abi.MethodNum) (cid.Cid, error) `perm:"write"`
+
 		MineSubnet func(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 bool) error `perm:"read"`
 
 		ReleaseFunds func(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 abi.TokenAmount) (cid.Cid, error) `perm:"write"`
@@ -3599,6 +3601,17 @@ func (s *HierarchicalCnsStruct) ListCheckpoints(p0 context.Context, p1 address.S
 
 func (s *HierarchicalCnsStub) ListCheckpoints(p0 context.Context, p1 address.SubnetID, p2 int) ([]*schema.Checkpoint, error) {
 	return *new([]*schema.Checkpoint), ErrNotSupported
+}
+
+func (s *HierarchicalCnsStruct) LockState(p0 context.Context, p1 address.Address, p2 address.Address, p3 address.SubnetID, p4 abi.MethodNum) (cid.Cid, error) {
+	if s.Internal.LockState == nil {
+		return *new(cid.Cid), ErrNotSupported
+	}
+	return s.Internal.LockState(p0, p1, p2, p3, p4)
+}
+
+func (s *HierarchicalCnsStub) LockState(p0 context.Context, p1 address.Address, p2 address.Address, p3 address.SubnetID, p4 abi.MethodNum) (cid.Cid, error) {
+	return *new(cid.Cid), ErrNotSupported
 }
 
 func (s *HierarchicalCnsStruct) MineSubnet(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 bool) error {

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -585,7 +585,7 @@ type HierarchicalCnsStruct struct {
 
 		LeaveSubnet func(p0 context.Context, p1 address.Address, p2 address.SubnetID) (cid.Cid, error) `perm:"write"`
 
-		ListAtomicExecs func(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]*sca.AtomicExec, error) `perm:"read"`
+		ListAtomicExecs func(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]sca.AtomicExec, error) `perm:"read"`
 
 		ListCheckpoints func(p0 context.Context, p1 address.SubnetID, p2 int) ([]*schema.Checkpoint, error) `perm:"read"`
 
@@ -596,6 +596,8 @@ type HierarchicalCnsStruct struct {
 		ReleaseFunds func(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 abi.TokenAmount) (cid.Cid, error) `perm:"write"`
 
 		SyncSubnet func(p0 context.Context, p1 address.SubnetID, p2 bool) error `perm:"write"`
+
+		UnlockState func(p0 context.Context, p1 address.Address, p2 address.Address, p3 address.SubnetID, p4 abi.MethodNum) error `perm:"write"`
 
 		ValidateCheckpoint func(p0 context.Context, p1 address.SubnetID, p2 abi.ChainEpoch) (*schema.Checkpoint, error) `perm:"read"`
 	}
@@ -3634,15 +3636,15 @@ func (s *HierarchicalCnsStub) LeaveSubnet(p0 context.Context, p1 address.Address
 	return *new(cid.Cid), ErrNotSupported
 }
 
-func (s *HierarchicalCnsStruct) ListAtomicExecs(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]*sca.AtomicExec, error) {
+func (s *HierarchicalCnsStruct) ListAtomicExecs(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]sca.AtomicExec, error) {
 	if s.Internal.ListAtomicExecs == nil {
-		return *new([]*sca.AtomicExec), ErrNotSupported
+		return *new([]sca.AtomicExec), ErrNotSupported
 	}
 	return s.Internal.ListAtomicExecs(p0, p1, p2)
 }
 
-func (s *HierarchicalCnsStub) ListAtomicExecs(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]*sca.AtomicExec, error) {
-	return *new([]*sca.AtomicExec), ErrNotSupported
+func (s *HierarchicalCnsStub) ListAtomicExecs(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]sca.AtomicExec, error) {
+	return *new([]sca.AtomicExec), ErrNotSupported
 }
 
 func (s *HierarchicalCnsStruct) ListCheckpoints(p0 context.Context, p1 address.SubnetID, p2 int) ([]*schema.Checkpoint, error) {
@@ -3697,6 +3699,17 @@ func (s *HierarchicalCnsStruct) SyncSubnet(p0 context.Context, p1 address.Subnet
 }
 
 func (s *HierarchicalCnsStub) SyncSubnet(p0 context.Context, p1 address.SubnetID, p2 bool) error {
+	return ErrNotSupported
+}
+
+func (s *HierarchicalCnsStruct) UnlockState(p0 context.Context, p1 address.Address, p2 address.Address, p3 address.SubnetID, p4 abi.MethodNum) error {
+	if s.Internal.UnlockState == nil {
+		return ErrNotSupported
+	}
+	return s.Internal.UnlockState(p0, p1, p2, p3, p4)
+}
+
+func (s *HierarchicalCnsStub) UnlockState(p0 context.Context, p1 address.Address, p2 address.Address, p3 address.SubnetID, p4 abi.MethodNum) error {
 	return ErrNotSupported
 }
 

--- a/api/proxy_gen.go
+++ b/api/proxy_gen.go
@@ -22,6 +22,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lotus/chain/actors/builtin/paych"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/checkpoints/schema"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/extern/sector-storage/fsutil"
@@ -564,7 +565,11 @@ type GatewayStub struct {
 
 type HierarchicalCnsStruct struct {
 	Internal struct {
+		AbortAtomicExec func(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 cid.Cid) (sca.ExecStatus, error) `perm:"write"`
+
 		AddSubnet func(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 string, p4 uint64, p5 abi.TokenAmount, p6 abi.ChainEpoch, p7 address.Address) (address.Address, error) `perm:"write"`
+
+		ComputeAndSubmitExec func(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 cid.Cid) (sca.ExecStatus, error) `perm:"write"`
 
 		CrossMsgResolve func(p0 context.Context, p1 address.SubnetID, p2 cid.Cid, p3 address.SubnetID) ([]types.Message, error) `perm:"read"`
 
@@ -572,11 +577,15 @@ type HierarchicalCnsStruct struct {
 
 		GetCrossMsgsPool func(p0 context.Context, p1 address.SubnetID, p2 abi.ChainEpoch) ([]*types.Message, error) `perm:"read"`
 
+		InitAtomicExec func(p0 context.Context, p1 address.Address, p2 map[string]sca.LockedState, p3 []types.Message) (cid.Cid, error) `perm:"write"`
+
 		JoinSubnet func(p0 context.Context, p1 address.Address, p2 abi.TokenAmount, p3 address.SubnetID) (cid.Cid, error) `perm:"write"`
 
 		KillSubnet func(p0 context.Context, p1 address.Address, p2 address.SubnetID) (cid.Cid, error) `perm:"write"`
 
 		LeaveSubnet func(p0 context.Context, p1 address.Address, p2 address.SubnetID) (cid.Cid, error) `perm:"write"`
+
+		ListAtomicExecs func(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]*sca.AtomicExec, error) `perm:"read"`
 
 		ListCheckpoints func(p0 context.Context, p1 address.SubnetID, p2 int) ([]*schema.Checkpoint, error) `perm:"read"`
 
@@ -3515,6 +3524,17 @@ func (s *GatewayStub) WalletBalance(p0 context.Context, p1 address.Address) (typ
 	return *new(types.BigInt), ErrNotSupported
 }
 
+func (s *HierarchicalCnsStruct) AbortAtomicExec(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 cid.Cid) (sca.ExecStatus, error) {
+	if s.Internal.AbortAtomicExec == nil {
+		return *new(sca.ExecStatus), ErrNotSupported
+	}
+	return s.Internal.AbortAtomicExec(p0, p1, p2, p3)
+}
+
+func (s *HierarchicalCnsStub) AbortAtomicExec(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 cid.Cid) (sca.ExecStatus, error) {
+	return *new(sca.ExecStatus), ErrNotSupported
+}
+
 func (s *HierarchicalCnsStruct) AddSubnet(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 string, p4 uint64, p5 abi.TokenAmount, p6 abi.ChainEpoch, p7 address.Address) (address.Address, error) {
 	if s.Internal.AddSubnet == nil {
 		return *new(address.Address), ErrNotSupported
@@ -3524,6 +3544,17 @@ func (s *HierarchicalCnsStruct) AddSubnet(p0 context.Context, p1 address.Address
 
 func (s *HierarchicalCnsStub) AddSubnet(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 string, p4 uint64, p5 abi.TokenAmount, p6 abi.ChainEpoch, p7 address.Address) (address.Address, error) {
 	return *new(address.Address), ErrNotSupported
+}
+
+func (s *HierarchicalCnsStruct) ComputeAndSubmitExec(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 cid.Cid) (sca.ExecStatus, error) {
+	if s.Internal.ComputeAndSubmitExec == nil {
+		return *new(sca.ExecStatus), ErrNotSupported
+	}
+	return s.Internal.ComputeAndSubmitExec(p0, p1, p2, p3)
+}
+
+func (s *HierarchicalCnsStub) ComputeAndSubmitExec(p0 context.Context, p1 address.Address, p2 address.SubnetID, p3 cid.Cid) (sca.ExecStatus, error) {
+	return *new(sca.ExecStatus), ErrNotSupported
 }
 
 func (s *HierarchicalCnsStruct) CrossMsgResolve(p0 context.Context, p1 address.SubnetID, p2 cid.Cid, p3 address.SubnetID) ([]types.Message, error) {
@@ -3559,6 +3590,17 @@ func (s *HierarchicalCnsStub) GetCrossMsgsPool(p0 context.Context, p1 address.Su
 	return *new([]*types.Message), ErrNotSupported
 }
 
+func (s *HierarchicalCnsStruct) InitAtomicExec(p0 context.Context, p1 address.Address, p2 map[string]sca.LockedState, p3 []types.Message) (cid.Cid, error) {
+	if s.Internal.InitAtomicExec == nil {
+		return *new(cid.Cid), ErrNotSupported
+	}
+	return s.Internal.InitAtomicExec(p0, p1, p2, p3)
+}
+
+func (s *HierarchicalCnsStub) InitAtomicExec(p0 context.Context, p1 address.Address, p2 map[string]sca.LockedState, p3 []types.Message) (cid.Cid, error) {
+	return *new(cid.Cid), ErrNotSupported
+}
+
 func (s *HierarchicalCnsStruct) JoinSubnet(p0 context.Context, p1 address.Address, p2 abi.TokenAmount, p3 address.SubnetID) (cid.Cid, error) {
 	if s.Internal.JoinSubnet == nil {
 		return *new(cid.Cid), ErrNotSupported
@@ -3590,6 +3632,17 @@ func (s *HierarchicalCnsStruct) LeaveSubnet(p0 context.Context, p1 address.Addre
 
 func (s *HierarchicalCnsStub) LeaveSubnet(p0 context.Context, p1 address.Address, p2 address.SubnetID) (cid.Cid, error) {
 	return *new(cid.Cid), ErrNotSupported
+}
+
+func (s *HierarchicalCnsStruct) ListAtomicExecs(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]*sca.AtomicExec, error) {
+	if s.Internal.ListAtomicExecs == nil {
+		return *new([]*sca.AtomicExec), ErrNotSupported
+	}
+	return s.Internal.ListAtomicExecs(p0, p1, p2)
+}
+
+func (s *HierarchicalCnsStub) ListAtomicExecs(p0 context.Context, p1 address.SubnetID, p2 address.Address) ([]*sca.AtomicExec, error) {
+	return *new([]*sca.AtomicExec), ErrNotSupported
 }
 
 func (s *HierarchicalCnsStruct) ListCheckpoints(p0 context.Context, p1 address.SubnetID, p2 int) ([]*schema.Checkpoint, error) {

--- a/api/v0api/v0mocks/mock_full.go
+++ b/api/v0api/v0mocks/mock_full.go
@@ -23,6 +23,7 @@ import (
 	apitypes "github.com/filecoin-project/lotus/api/types"
 	v0api "github.com/filecoin-project/lotus/api/v0api"
 	miner "github.com/filecoin-project/lotus/chain/actors/builtin/miner"
+	sca "github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	schema "github.com/filecoin-project/lotus/chain/consensus/hierarchical/checkpoints/schema"
 	types "github.com/filecoin-project/lotus/chain/types"
 	alerting "github.com/filecoin-project/lotus/journal/alerting"
@@ -61,6 +62,21 @@ func NewMockFullNode(ctrl *gomock.Controller) *MockFullNode {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFullNode) EXPECT() *MockFullNodeMockRecorder {
 	return m.recorder
+}
+
+// AbortAtomicExec mocks base method.
+func (m *MockFullNode) AbortAtomicExec(arg0 context.Context, arg1 address.Address, arg2 address.SubnetID, arg3 cid.Cid) (sca.ExecStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AbortAtomicExec", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(sca.ExecStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AbortAtomicExec indicates an expected call of AbortAtomicExec.
+func (mr *MockFullNodeMockRecorder) AbortAtomicExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AbortAtomicExec", reflect.TypeOf((*MockFullNode)(nil).AbortAtomicExec), arg0, arg1, arg2, arg3)
 }
 
 // AddSubnet mocks base method.
@@ -864,6 +880,21 @@ func (mr *MockFullNodeMockRecorder) Closing(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Closing", reflect.TypeOf((*MockFullNode)(nil).Closing), arg0)
 }
 
+// ComputeAndSubmitExec mocks base method.
+func (m *MockFullNode) ComputeAndSubmitExec(arg0 context.Context, arg1 address.Address, arg2 address.SubnetID, arg3 cid.Cid) (sca.ExecStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ComputeAndSubmitExec", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(sca.ExecStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ComputeAndSubmitExec indicates an expected call of ComputeAndSubmitExec.
+func (mr *MockFullNodeMockRecorder) ComputeAndSubmitExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeAndSubmitExec", reflect.TypeOf((*MockFullNode)(nil).ComputeAndSubmitExec), arg0, arg1, arg2, arg3)
+}
+
 // CreateBackup mocks base method.
 func (m *MockFullNode) CreateBackup(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -1013,6 +1044,21 @@ func (mr *MockFullNodeMockRecorder) ID(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockFullNode)(nil).ID), arg0)
 }
 
+// InitAtomicExec mocks base method.
+func (m *MockFullNode) InitAtomicExec(arg0 context.Context, arg1 address.Address, arg2 map[string]sca.LockedState, arg3 []types.Message) (cid.Cid, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitAtomicExec", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(cid.Cid)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InitAtomicExec indicates an expected call of InitAtomicExec.
+func (mr *MockFullNodeMockRecorder) InitAtomicExec(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitAtomicExec", reflect.TypeOf((*MockFullNode)(nil).InitAtomicExec), arg0, arg1, arg2, arg3)
+}
+
 // JoinSubnet mocks base method.
 func (m *MockFullNode) JoinSubnet(arg0 context.Context, arg1 address.Address, arg2 big.Int, arg3 address.SubnetID) (cid.Cid, error) {
 	m.ctrl.T.Helper()
@@ -1056,6 +1102,21 @@ func (m *MockFullNode) LeaveSubnet(arg0 context.Context, arg1 address.Address, a
 func (mr *MockFullNodeMockRecorder) LeaveSubnet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveSubnet", reflect.TypeOf((*MockFullNode)(nil).LeaveSubnet), arg0, arg1, arg2)
+}
+
+// ListAtomicExecs mocks base method.
+func (m *MockFullNode) ListAtomicExecs(arg0 context.Context, arg1 address.SubnetID, arg2 address.Address) ([]*sca.AtomicExec, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAtomicExecs", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*sca.AtomicExec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAtomicExecs indicates an expected call of ListAtomicExecs.
+func (mr *MockFullNodeMockRecorder) ListAtomicExecs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAtomicExecs", reflect.TypeOf((*MockFullNode)(nil).ListAtomicExecs), arg0, arg1, arg2)
 }
 
 // ListCheckpoints mocks base method.

--- a/api/v0api/v0mocks/mock_full.go
+++ b/api/v0api/v0mocks/mock_full.go
@@ -1073,6 +1073,21 @@ func (mr *MockFullNodeMockRecorder) ListCheckpoints(arg0, arg1, arg2 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCheckpoints", reflect.TypeOf((*MockFullNode)(nil).ListCheckpoints), arg0, arg1, arg2)
 }
 
+// LockState mocks base method.
+func (m *MockFullNode) LockState(arg0 context.Context, arg1, arg2 address.Address, arg3 address.SubnetID, arg4 abi.MethodNum) (cid.Cid, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LockState", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(cid.Cid)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LockState indicates an expected call of LockState.
+func (mr *MockFullNodeMockRecorder) LockState(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockState", reflect.TypeOf((*MockFullNode)(nil).LockState), arg0, arg1, arg2, arg3, arg4)
+}
+
 // LogAlerts mocks base method.
 func (m *MockFullNode) LogAlerts(arg0 context.Context) ([]alerting.Alert, error) {
 	m.ctrl.T.Helper()

--- a/api/v0api/v0mocks/mock_full.go
+++ b/api/v0api/v0mocks/mock_full.go
@@ -1105,10 +1105,10 @@ func (mr *MockFullNodeMockRecorder) LeaveSubnet(arg0, arg1, arg2 interface{}) *g
 }
 
 // ListAtomicExecs mocks base method.
-func (m *MockFullNode) ListAtomicExecs(arg0 context.Context, arg1 address.SubnetID, arg2 address.Address) ([]*sca.AtomicExec, error) {
+func (m *MockFullNode) ListAtomicExecs(arg0 context.Context, arg1 address.SubnetID, arg2 address.Address) ([]sca.AtomicExec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAtomicExecs", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]*sca.AtomicExec)
+	ret0, _ := ret[0].([]sca.AtomicExec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3199,6 +3199,20 @@ func (m *MockFullNode) SyncValidateTipset(arg0 context.Context, arg1 types.TipSe
 func (mr *MockFullNodeMockRecorder) SyncValidateTipset(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncValidateTipset", reflect.TypeOf((*MockFullNode)(nil).SyncValidateTipset), arg0, arg1)
+}
+
+// UnlockState mocks base method.
+func (m *MockFullNode) UnlockState(arg0 context.Context, arg1, arg2 address.Address, arg3 address.SubnetID, arg4 abi.MethodNum) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnlockState", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnlockState indicates an expected call of UnlockState.
+func (mr *MockFullNodeMockRecorder) UnlockState(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlockState", reflect.TypeOf((*MockFullNode)(nil).UnlockState), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ValidateCheckpoint mocks base method.

--- a/chain/consensus/actors/atomic-replace/replace_test.go
+++ b/chain/consensus/actors/atomic-replace/replace_test.go
@@ -3,9 +3,10 @@ package replace_test
 import (
 	"testing"
 
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	actors "github.com/filecoin-project/lotus/chain/consensus/actors"
 	replace "github.com/filecoin-project/lotus/chain/consensus/actors/atomic-replace"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical"
 	atomic "github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
 	"github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	"github.com/filecoin-project/specs-actors/v7/actors/builtin"
@@ -15,8 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var cidUndef, _ = abi.CidBuilder.Sum([]byte("test"))
 
 func TestExports(t *testing.T) {
 	mock.CheckActorExports(t, replace.ReplaceActor{})
@@ -179,11 +178,10 @@ func TestUnlock(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 
-	rt.SetCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
-	ls := &replace.Owners{M: map[string]cid.Cid{"test": cidUndef, target.String(): cidUndef}}
+	rt.SetCaller(hierarchical.SubnetCoordActorAddr, actors.SubnetCoordActorCodeID)
+	ls := &replace.Owners{M: map[string]cid.Cid{"test": replace.CidUndef, target.String(): replace.CidUndef}}
 	require.NoError(t, err)
-	// rt.ExpectValidateCallerAddr(builtin.SystemActorAddr)
-	rt.ExpectValidateCallerAny()
+	rt.ExpectValidateCallerAddr(hierarchical.SubnetCoordActorAddr)
 	params, err := atomic.WrapUnlockParams(lockparams, ls)
 	require.NoError(t, err)
 	rt.Call(h.ReplaceActor.Unlock, params)
@@ -192,7 +190,7 @@ func TestUnlock(t *testing.T) {
 	require.NoError(t, err)
 	own1, ok := owners.M["test"]
 	require.True(t, ok)
-	require.Equal(t, own1, cidUndef)
+	require.Equal(t, own1, replace.CidUndef)
 	_, ok = owners.M[target.String()]
 	require.True(t, ok)
 
@@ -218,8 +216,8 @@ func TestMerge(t *testing.T) {
 	rt.Verify()
 
 	rt.SetCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
-	ls1 := &replace.Owners{M: map[string]cid.Cid{"test": cidUndef}}
-	ls2 := &replace.Owners{M: map[string]cid.Cid{"test2": cidUndef}}
+	ls1 := &replace.Owners{M: map[string]cid.Cid{"test": replace.CidUndef}}
+	ls2 := &replace.Owners{M: map[string]cid.Cid{"test2": replace.CidUndef}}
 	require.NoError(t, err)
 	params, err := atomic.WrapMergeParams(ls1)
 	require.NoError(t, err)
@@ -234,10 +232,10 @@ func TestMerge(t *testing.T) {
 	require.NoError(t, err)
 	own1, ok := owners.M["test"]
 	require.True(t, ok)
-	require.Equal(t, own1, cidUndef)
+	require.Equal(t, own1, replace.CidUndef)
 	own2, ok := owners.M["test2"]
 	require.True(t, ok)
-	require.Equal(t, own2, cidUndef)
+	require.Equal(t, own2, replace.CidUndef)
 }
 
 type shActorHarness struct {

--- a/chain/consensus/hierarchical/actors/sca/cbor_gen.go
+++ b/chain/consensus/hierarchical/actors/sca/cbor_gen.go
@@ -1553,7 +1553,7 @@ func (t *SubmitOutput) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufLockedState = []byte{131}
+var lengthBufLockedState = []byte{130}
 
 func (t *LockedState) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1565,18 +1565,6 @@ func (t *LockedState) MarshalCBOR(w io.Writer) error {
 	}
 
 	scratch := make([]byte, 9)
-
-	// t.From (address.SubnetID) (string)
-	if len(t.From) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.From was too long")
-	}
-
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len(t.From))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.From)); err != nil {
-		return err
-	}
 
 	// t.Cid (string) (string)
 	if len(t.Cid) > cbg.MaxLength {
@@ -1611,20 +1599,10 @@ func (t *LockedState) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.From (address.SubnetID) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.From = address.SubnetID(sval)
-	}
 	// t.Cid (string) (string)
 
 	{

--- a/chain/consensus/hierarchical/actors/sca/cbor_gen.go
+++ b/chain/consensus/hierarchical/actors/sca/cbor_gen.go
@@ -1553,7 +1553,7 @@ func (t *SubmitOutput) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufLockedState = []byte{130}
+var lengthBufLockedState = []byte{131}
 
 func (t *LockedState) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1589,6 +1589,11 @@ func (t *LockedState) MarshalCBOR(w io.Writer) error {
 	if _, err := io.WriteString(w, string(t.Cid)); err != nil {
 		return err
 	}
+
+	// t.Actor (address.Address) (struct)
+	if err := t.Actor.MarshalCBOR(w); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1606,7 +1611,7 @@ func (t *LockedState) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1629,6 +1634,15 @@ func (t *LockedState) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.Cid = string(sval)
+	}
+	// t.Actor (address.Address) (struct)
+
+	{
+
+		if err := t.Actor.UnmarshalCBOR(br); err != nil {
+			return xerrors.Errorf("unmarshaling t.Actor: %w", err)
+		}
+
 	}
 	return nil
 }

--- a/chain/consensus/hierarchical/actors/sca/cbor_gen.go
+++ b/chain/consensus/hierarchical/actors/sca/cbor_gen.go
@@ -1113,23 +1113,23 @@ func (t *AtomicExec) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Output (map[string]cid.Cid) (map)
+	// t.Submitted (map[string]cid.Cid) (map)
 	{
-		if len(t.Output) > 4096 {
-			return xerrors.Errorf("cannot marshal t.Output map too large")
+		if len(t.Submitted) > 4096 {
+			return xerrors.Errorf("cannot marshal t.Submitted map too large")
 		}
 
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.Output))); err != nil {
+		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, uint64(len(t.Submitted))); err != nil {
 			return err
 		}
 
-		keys := make([]string, 0, len(t.Output))
-		for k := range t.Output {
+		keys := make([]string, 0, len(t.Submitted))
+		for k := range t.Submitted {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			v := t.Output[k]
+			v := t.Submitted[k]
 
 			if len(k) > cbg.MaxLength {
 				return xerrors.Errorf("Value in field k was too long")
@@ -1185,7 +1185,7 @@ func (t *AtomicExec) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.Output (map[string]cid.Cid) (map)
+	// t.Submitted (map[string]cid.Cid) (map)
 
 	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 	if err != nil {
@@ -1195,10 +1195,10 @@ func (t *AtomicExec) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("expected a map (major type 5)")
 	}
 	if extra > 4096 {
-		return fmt.Errorf("t.Output: map too large")
+		return fmt.Errorf("t.Submitted: map too large")
 	}
 
-	t.Output = make(map[string]cid.Cid, extra)
+	t.Submitted = make(map[string]cid.Cid, extra)
 
 	for i, l := 0, int(extra); i < l; i++ {
 
@@ -1226,7 +1226,7 @@ func (t *AtomicExec) UnmarshalCBOR(r io.Reader) error {
 
 		}
 
-		t.Output[k] = v
+		t.Submitted[k] = v
 
 	}
 	// t.Status (sca.ExecStatus) (uint64)

--- a/chain/consensus/hierarchical/actors/sca/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -23,6 +23,7 @@ func main() {
 		actor.SubmitExecParams{},
 		actor.SubmitOutput{},
 		actor.LockedState{},
+		actor.OutputCid{},
 	); err != nil {
 		panic(err)
 	}

--- a/chain/consensus/hierarchical/actors/sca/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -20,7 +20,6 @@ func main() {
 		actor.ErrorParam{},
 		actor.AtomicExec{},
 		actor.AtomicExecParams{},
-		actor.LockedState{},
 		actor.SubmitExecParams{},
 		actor.SubmitOutput{},
 	); err != nil {

--- a/chain/consensus/hierarchical/actors/sca/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -22,6 +22,7 @@ func main() {
 		actor.AtomicExecParams{},
 		actor.SubmitExecParams{},
 		actor.SubmitOutput{},
+		actor.LockedState{},
 	); err != nil {
 		panic(err)
 	}

--- a/chain/consensus/hierarchical/actors/sca/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/sca/gen/gen.go
@@ -18,6 +18,11 @@ func main() {
 		actor.MetaTag{},
 		actor.CrossMsgParams{},
 		actor.ErrorParam{},
+		actor.AtomicExec{},
+		actor.AtomicExecParams{},
+		actor.LockedState{},
+		actor.SubmitExecParams{},
+		actor.SubmitOutput{},
 	); err != nil {
 		panic(err)
 	}

--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -678,12 +678,12 @@ func (a SubnetCoordActor) SubmitAtomicExec(rt runtime.Runtime, params *SubmitExe
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error getting exec map")
 		// Check if execution exists.
 		var found bool
-		execCid, err := cid.Decode(params.ID)
+		execCid, err := cid.Decode(params.Cid)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalArgument, "error getting exec map")
 		exec, found, err = getAtomicExec(execMap, execCid)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error getting exec map")
 		if !found {
-			rt.Abortf(exitcode.ErrIllegalArgument, "execution with cid %s not found", params.ID)
+			rt.Abortf(exitcode.ErrIllegalArgument, "execution with cid %s not found", params.Cid)
 		}
 
 		// Check if the output has been aborted or succeeded.

--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -659,6 +659,10 @@ func (a SubnetCoordActor) InitAtomicExec(rt runtime.Runtime, params *AtomicExecP
 			rt.Abortf(exitcode.ErrIllegalArgument, "execution with cid %s already initialized", c)
 		}
 
+		if len(params.Msgs) == 0 || len(params.Inputs) == 0 {
+			rt.Abortf(exitcode.ErrIllegalArgument, "no msgs or inputs provided for execution")
+		}
+
 		// sanity-check: verify that all messages have same method and are directed to the same actor.
 		method := params.Msgs[0].Method
 		to := params.Msgs[0].To

--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -692,7 +692,7 @@ func (a SubnetCoordActor) InitAtomicExec(rt runtime.Runtime, params *AtomicExecP
 			}
 		}
 		// Store new initialized execution
-		err = st.putExecWithCid(execMap, c, &AtomicExec{Params: *params, Submitted: make(map[string]cid.Cid), Status: ExecInitialized})
+		err = st.putExecWithCid(execMap, c, &AtomicExec{Params: *params, Submitted: make(map[string]OutputCid), Status: ExecInitialized})
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error storing new atomic execution")
 	})
 
@@ -753,12 +753,12 @@ func (a SubnetCoordActor) SubmitAtomicExec(rt runtime.Runtime, params *SubmitExe
 		for _, o := range exec.Submitted {
 			// NOTE: checking one should be enough and we could make it more efficient
 			// like that, but checking all for now as a sanity-check.
-			if o != outputCid {
+			if o.Cid != outputCid.String() {
 				rt.Abortf(exitcode.ErrIllegalArgument, "outputs don't match")
 				// FIXME: Should we abort right-away if this happens.
 			}
 		}
-		exec.Submitted[caller.String()] = outputCid
+		exec.Submitted[caller.String()] = OutputCid{Cid: outputCid.String()}
 		// If it is the final output update state of the execution.
 		if len(exec.Submitted) == len(exec.Params.Inputs) {
 			exec.Status = ExecSuccess

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic.go
@@ -62,8 +62,9 @@ type AtomicExecParams struct {
 }
 
 type LockedState struct {
-	From address.SubnetID
-	Cid  string // NOTE: Storing cid as string so it can be used as input parameter in actor fn.
+	From  address.SubnetID
+	Cid   string // NOTE: Storing cid as string so it can be used as input parameter in actor fn.
+	Actor address.Address
 }
 
 func (st *SCAState) putExecWithCid(execMap *adt.Map, c cid.Cid, exec *AtomicExec) error {
@@ -111,7 +112,7 @@ func (ae *AtomicExecParams) Cid() (cid.Cid, error) {
 	}
 
 	for _, input := range ae.Inputs {
-		mc, err := abi.CidBuilder.Sum([]byte(input.From.String() + input.Cid))
+		mc, err := abi.CidBuilder.Sum([]byte(input.From.String() + input.Cid + input.Actor.String()))
 		if err != nil {
 			return cid.Undef, err
 		}

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic.go
@@ -1,0 +1,152 @@
+package sca
+
+import (
+	"context"
+
+	address "github.com/filecoin-project/go-address"
+	abi "github.com/filecoin-project/go-state-types/abi"
+	bstore "github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
+	types "github.com/filecoin-project/lotus/chain/types"
+	blockadt "github.com/filecoin-project/specs-actors/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/v7/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v7/actors/util/adt"
+	cid "github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	xerrors "golang.org/x/xerrors"
+)
+
+type ExecStatus uint64
+
+const (
+	Initialized ExecStatus = iota
+	Success
+	Aborted
+)
+
+type AtomicExec struct {
+	Params AtomicExecParams
+	Output map[string]cid.Cid
+	Status ExecStatus
+}
+
+type SubmitExecParams struct {
+	ID     cid.Cid
+	Abort  bool
+	Output cid.Cid
+}
+
+type SubmitOutput struct {
+	Status ExecStatus
+}
+
+type AtomicExecParams struct {
+	Msgs   []types.Message
+	Inputs []LockedState
+}
+
+type LockedState struct {
+	From  address.Address
+	State atomic.LockedState
+}
+
+func (st *SCAState) putExec(execMap *adt.Map, exec *AtomicExec) (cid.Cid, error) {
+	execCid, err := exec.Params.Cid()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return execCid, st.putExecWithCid(execMap, execCid, exec)
+}
+
+func (st *SCAState) putExecWithCid(execMap *adt.Map, c cid.Cid, exec *AtomicExec) error {
+	var err error
+	if err := execMap.Put(abi.CidKey(c), exec); err != nil {
+		return err
+	}
+	st.AtomicExecRegistry, err = execMap.Root()
+	return err
+}
+
+func (st *SCAState) GetAtomicExec(s adt.Store, c cid.Cid) (*AtomicExec, bool, error) {
+	execMap, err := adt.AsMap(s, st.AtomicExecRegistry, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to load atomic exec: %w", err)
+	}
+	return getAtomicExec(execMap, c)
+}
+
+func getAtomicExec(execMap *adt.Map, c cid.Cid) (*AtomicExec, bool, error) {
+	var out AtomicExec
+	found, err := execMap.Get(abi.CidKey(c), &out)
+	if err != nil {
+		return nil, false, xerrors.Errorf("failed to get execution for cid %v: %w", c, err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+	return &out, true, nil
+}
+
+/*
+func putExec(execMap *adt.Map, exec *AtomicExec) (cid.Cid, error) {
+	execCid, err := exec.Params.Cid()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return execCid, execMap.Put(abi.CidKey(execCid), exec)
+}
+
+
+func (st *SCAState) flushCheckpoint(rt runtime.Runtime, ch *schema.Checkpoint) {
+	// Update subnet in the list of checkpoints.
+	checks, err := adt.AsMap(adt.AsStore(rt), st.Checkpoints, builtin.DefaultHamtBitwidth)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to load state for checkpoints")
+	err = checks.Put(abi.UIntKey(uint64(ch.Data.Epoch)), ch)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to put checkpoint in map")
+	// Flush checkpoints
+	st.Checkpoints, err = checks.Root()
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "failed to flush checkpoints")
+}
+*/
+
+// Cid computes the cid for the CrossMsg
+func (ae *AtomicExecParams) Cid() (cid.Cid, error) {
+	cst := cbor.NewCborStore(bstore.NewMemory())
+	store := blockadt.WrapStore(context.TODO(), cst)
+	cArr := blockadt.MakeEmptyArray(store)
+	mArr := blockadt.MakeEmptyArray(store)
+
+	// Compute CID for list of messages generated in subnet
+	for i, m := range ae.Msgs {
+		c := cbg.CborCid(m.Cid())
+		if err := cArr.Set(uint64(i), &c); err != nil {
+			return cid.Undef, err
+		}
+	}
+
+	for i, input := range ae.Inputs {
+		mc, err := input.State.Cid()
+		if err != nil {
+			return cid.Undef, err
+		}
+		c := cbg.CborCid(mc)
+		if err := mArr.Set(uint64(i), &c); err != nil {
+			return cid.Undef, err
+		}
+	}
+
+	croot, err := cArr.Root()
+	if err != nil {
+		return cid.Undef, err
+	}
+	mroot, err := mArr.Root()
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return store.Put(store.Context(), &MetaTag{
+		MsgsCid:  croot,
+		MetasCid: mroot,
+	})
+}

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic.go
@@ -41,11 +41,15 @@ var ExecStatusStr = map[ExecStatus]string{
 	ExecAborted:     "Aborted",
 }
 
+type OutputCid struct {
+	Cid string
+}
+
 // AtomicExec is the data structure held by SCA for
 // atomic executions.
 type AtomicExec struct {
 	Params    AtomicExecParams
-	Submitted map[string]cid.Cid
+	Submitted map[string]OutputCid
 	Status    ExecStatus
 }
 

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic.go
@@ -16,14 +16,20 @@ import (
 	xerrors "golang.org/x/xerrors"
 )
 
+// ExecStatus defines the different state an execution can be in
 type ExecStatus uint64
 
 const (
+	// ExecInitialized and waiting for submissions.
 	ExecInitialized ExecStatus = iota
+	// ExecSuccess - all submissions matched.
 	ExecSuccess
+	// ExecAborted - some party aborted the execution
 	ExecAborted
 )
 
+// AtomicExec is the data structure held by SCA for
+// atomic executions.
 type AtomicExec struct {
 	Params AtomicExecParams
 	Output map[string]cid.Cid
@@ -40,6 +46,11 @@ type SubmitOutput struct {
 	Status ExecStatus
 }
 
+// AtomicExecParams determines the conditions (input, msgs) for the atomic
+// execution.
+//
+// Parties involved in the protocol use this information to perform their
+// off-chain execution stage.
 type AtomicExecParams struct {
 	Msgs   []types.Message
 	Inputs map[string]atomic.LockedState

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
@@ -57,7 +57,7 @@ func TestAtomicExec(t *testing.T) {
 	output, err := atomic.WrapLockableState(&replace.Owners{M: map[string]cid.Cid{other.String(): cidOut}})
 	require.NoError(t, err)
 	oparams := &actor.SubmitExecParams{
-		ID:     execCid.String(),
+		Cid:    execCid.String(),
 		Output: *output,
 	}
 	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
@@ -83,7 +83,7 @@ func TestAtomicExec(t *testing.T) {
 		output, err := atomic.WrapLockableState(&replace.Owners{M: map[string]cid.Cid{other.String(): c}})
 		require.NoError(t, err)
 		ps := &actor.SubmitExecParams{
-			ID:     execCid.String(),
+			Cid:    execCid.String(),
 			Output: *output,
 		}
 		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, ps)
@@ -127,7 +127,7 @@ func TestAbort(t *testing.T) {
 	rt.SetCaller(caller, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
 	oparams := &actor.SubmitExecParams{
-		ID:    execCid.String(),
+		Cid:   execCid.String(),
 		Abort: true,
 	}
 	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
@@ -158,17 +158,11 @@ func execMsgs(t *testing.T, addr address.Address) []types.Message {
 	}
 }
 
-func lockedStates(t *testing.T, caller, other address.Address) map[string]atomic.LockedState {
+func lockedStates(t *testing.T, caller, other address.Address) map[string]actor.LockedState {
 	c1, _ := abi.CidBuilder.Sum([]byte("test1"))
 	c2, _ := abi.CidBuilder.Sum([]byte("test2"))
-	own1 := &replace.Owners{M: map[string]cid.Cid{caller.String(): c1}}
-	own2 := &replace.Owners{M: map[string]cid.Cid{other.String(): c2}}
-	wown1, err := atomic.WrapLockableState(own1)
-	require.NoError(t, err)
-	wown2, err := atomic.WrapLockableState(own2)
-	require.NoError(t, err)
-	return map[string]atomic.LockedState{
-		caller.String(): *wown1,
-		other.String():  *wown2,
+	return map[string]actor.LockedState{
+		caller.String(): {From: address.SubnetID("test1"), Cid: c1.String()},
+		other.String():  {From: address.SubnetID("tes2"), Cid: c2.String()},
 	}
 }

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
@@ -1,0 +1,174 @@
+package sca_test
+
+import (
+	"testing"
+
+	address "github.com/filecoin-project/go-address"
+	abi "github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-state-types/exitcode"
+	replace "github.com/filecoin-project/lotus/chain/consensus/actors/atomic-replace"
+	actor "github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
+	atomic "github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
+	types "github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/v7/actors/builtin"
+	"github.com/filecoin-project/specs-actors/v7/actors/util/adt"
+	"github.com/filecoin-project/specs-actors/v7/support/mock"
+	tutil "github.com/filecoin-project/specs-actors/v7/support/testing"
+	cid "github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicExec(t *testing.T) {
+	h := newHarness(t)
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	rt := builder.Build(t)
+	h.constructAndVerify(rt)
+	caller := tutil.NewIDAddr(t, 101)
+	other := tutil.NewIDAddr(t, 102)
+
+	t.Log("init new atomic execution")
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	params := &actor.AtomicExecParams{
+		Msgs:   execMsgs(t, other),
+		Inputs: lockedStates(t, caller, other),
+	}
+	ret := rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
+	st := getState(rt)
+	execCid := ret.(*atomic.LockedOutput).Cid
+	exec, found, err := st.GetAtomicExec(adt.AsStore(rt), execCid)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, &exec.Params, params)
+	require.Equal(t, exec.Status, actor.ExecInitialized)
+
+	t.Log("try initializing it again")
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
+	})
+
+	t.Log("caller submits output")
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	cidOut, _ := abi.CidBuilder.Sum([]byte("outputTest"))
+	output, err := atomic.WrapLockableState(&replace.Owners{M: map[string]cid.Cid{other.String(): cidOut}})
+	require.NoError(t, err)
+	oparams := &actor.SubmitExecParams{
+		ID:     execCid.String(),
+		Output: *output,
+	}
+	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecInitialized)
+
+	t.Log("fail if resubmission or caller not involved")
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	})
+	stranger := tutil.NewIDAddr(t, 103)
+	rt.SetCaller(stranger, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	})
+
+	t.Log("submitting the wrong output fails")
+	rt.SetCaller(other, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		c, _ := abi.CidBuilder.Sum([]byte("test1"))
+		output, err := atomic.WrapLockableState(&replace.Owners{M: map[string]cid.Cid{other.String(): c}})
+		require.NoError(t, err)
+		ps := &actor.SubmitExecParams{
+			ID:     execCid.String(),
+			Output: *output,
+		}
+		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, ps)
+	})
+
+	t.Log("execution succeeds and no new submissions accepted")
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecSuccess)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
+		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	})
+}
+
+func TestAbort(t *testing.T) {
+	h := newHarness(t)
+	builder := mock.NewBuilder(builtin.StoragePowerActorAddr).WithCaller(builtin.SystemActorAddr, builtin.SystemActorCodeID)
+	rt := builder.Build(t)
+	h.constructAndVerify(rt)
+	caller := tutil.NewIDAddr(t, 101)
+	other := tutil.NewIDAddr(t, 102)
+
+	t.Log("init new atomic execution")
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	params := &actor.AtomicExecParams{
+		Msgs:   execMsgs(t, other),
+		Inputs: lockedStates(t, caller, other),
+	}
+	ret := rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
+	st := getState(rt)
+	execCid := ret.(*atomic.LockedOutput).Cid
+	exec, found, err := st.GetAtomicExec(adt.AsStore(rt), execCid)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, &exec.Params, params)
+	require.Equal(t, exec.Status, actor.ExecInitialized)
+
+	t.Log("caller aborts execution, no more submissions allowed")
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	oparams := &actor.SubmitExecParams{
+		ID:    execCid.String(),
+		Abort: true,
+	}
+	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecAborted)
+}
+func execMsgs(t *testing.T, addr address.Address) []types.Message {
+	return []types.Message{
+		{
+			From:       addr,
+			To:         addr,
+			Value:      abi.NewTokenAmount(0),
+			Method:     replace.MethodOwn,
+			Params:     nil,
+			GasPremium: big.Zero(),
+			GasFeeCap:  big.Zero(),
+			GasLimit:   0,
+		},
+		{
+			From:       addr,
+			To:         addr,
+			Value:      abi.NewTokenAmount(0),
+			Method:     replace.MethodReplace,
+			Params:     nil,
+			GasPremium: big.Zero(),
+			GasFeeCap:  big.Zero(),
+			GasLimit:   0,
+		},
+	}
+}
+
+func lockedStates(t *testing.T, caller, other address.Address) map[string]atomic.LockedState {
+	c1, _ := abi.CidBuilder.Sum([]byte("test1"))
+	c2, _ := abi.CidBuilder.Sum([]byte("test2"))
+	own1 := &replace.Owners{M: map[string]cid.Cid{caller.String(): c1}}
+	own2 := &replace.Owners{M: map[string]cid.Cid{other.String(): c2}}
+	wown1, err := atomic.WrapLockableState(own1)
+	require.NoError(t, err)
+	wown2, err := atomic.WrapLockableState(own2)
+	require.NoError(t, err)
+	return map[string]atomic.LockedState{
+		caller.String(): *wown1,
+		other.String():  *wown2,
+	}
+}

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
@@ -7,6 +7,7 @@ import (
 	abi "github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-state-types/exitcode"
+	"github.com/filecoin-project/lotus/chain/actors"
 	replace "github.com/filecoin-project/lotus/chain/consensus/actors/atomic-replace"
 	actor "github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	atomic "github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
@@ -27,12 +28,17 @@ func TestAtomicExec(t *testing.T) {
 	caller := tutil.NewIDAddr(t, 101)
 	other := tutil.NewIDAddr(t, 102)
 
+	snAddr1 := tutil.NewIDAddr(t, 1000)
+	sn1 := h.registerSubnet(rt, address.RootSubnet, snAddr1)
+	snAddr2 := tutil.NewIDAddr(t, 1001)
+	sn2 := h.registerSubnet(rt, address.RootSubnet, snAddr2)
+
 	t.Log("init new atomic execution")
 	rt.SetCaller(caller, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
 	params := &actor.AtomicExecParams{
 		Msgs:   execMsgs(t, other),
-		Inputs: lockedStates(t, caller, other),
+		Inputs: lockedStates(t, sn1, sn2, caller, other),
 	}
 	ret := rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
 	st := getState(rt)
@@ -97,6 +103,43 @@ func TestAtomicExec(t *testing.T) {
 	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	})
+
+	t.Log("check propagation messages in top-down message")
+	sh, found := h.getSubnet(rt, sn1)
+	require.True(h.t, found)
+	msg, found, err := sh.GetTopDownMsg(adt.AsStore(rt), 0)
+	require.NoError(h.t, err)
+	require.True(h.t, found)
+	exp, err := address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.From, exp)
+	exp, err = address.NewHAddress(sn1, other)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.To, exp)
+	require.Equal(h.t, msg.Method, atomic.MethodUnlock)
+
+	sh, found = h.getSubnet(rt, sn2)
+	require.True(h.t, found)
+	msg, found, err = sh.GetTopDownMsg(adt.AsStore(rt), 0)
+	require.NoError(h.t, err)
+	require.True(h.t, found)
+	exp, err = address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.From, exp)
+	exp, err = address.NewHAddress(sn2, other)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.To, exp)
+	require.Equal(h.t, msg.Method, atomic.MethodUnlock)
+
+	t.Log("check that we are propagating the right params")
+	inputMsg := execMsgs(t, other)[0]
+	lparams, err := atomic.WrapSerializedParams(inputMsg.Method, inputMsg.Params)
+	builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error wrapping serialized lock params")
+	uparams, err := atomic.WrapSerializedUnlockParams(lparams, output.S)
+	require.NoError(t, err)
+	enc, err := actors.SerializeParams(uparams)
+	require.NoError(t, err)
+	require.Equal(t, enc, msg.Params)
 }
 
 func TestAbort(t *testing.T) {
@@ -107,12 +150,17 @@ func TestAbort(t *testing.T) {
 	caller := tutil.NewIDAddr(t, 101)
 	other := tutil.NewIDAddr(t, 102)
 
+	snAddr1 := tutil.NewIDAddr(t, 1000)
+	sn1 := h.registerSubnet(rt, address.RootSubnet, snAddr1)
+	snAddr2 := tutil.NewIDAddr(t, 1001)
+	sn2 := h.registerSubnet(rt, address.RootSubnet, snAddr2)
+
 	t.Log("init new atomic execution")
 	rt.SetCaller(caller, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
 	params := &actor.AtomicExecParams{
 		Msgs:   execMsgs(t, other),
-		Inputs: lockedStates(t, caller, other),
+		Inputs: lockedStates(t, sn1, sn2, caller, other),
 	}
 	ret := rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
 	st := getState(rt)
@@ -132,14 +180,43 @@ func TestAbort(t *testing.T) {
 	}
 	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecAborted)
+
+	t.Log("check propagation messages in top-down message")
+	sh, found := h.getSubnet(rt, sn1)
+	require.True(h.t, found)
+	msg, found, err := sh.GetTopDownMsg(adt.AsStore(rt), 0)
+	require.NoError(h.t, err)
+	require.True(h.t, found)
+	exp, err := address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.From, exp)
+	exp, err = address.NewHAddress(sn1, other)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.To, exp)
+	require.Equal(h.t, msg.Method, atomic.MethodAbort)
+
+	sh, found = h.getSubnet(rt, sn2)
+	require.True(h.t, found)
+	msg, found, err = sh.GetTopDownMsg(adt.AsStore(rt), 0)
+	require.NoError(h.t, err)
+	require.True(h.t, found)
+	exp, err = address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
+	require.NoError(t, err)
+	require.Equal(h.t, msg.From, exp)
+	exp, err = address.NewHAddress(sn2, other)
+	require.NoError(t, err)
+
+	require.Equal(h.t, msg.To, exp)
+	require.Equal(h.t, msg.Method, atomic.MethodAbort)
 }
+
 func execMsgs(t *testing.T, addr address.Address) []types.Message {
 	return []types.Message{
 		{
 			From:       addr,
 			To:         addr,
 			Value:      abi.NewTokenAmount(0),
-			Method:     replace.MethodOwn,
+			Method:     replace.MethodReplace,
 			Params:     nil,
 			GasPremium: big.Zero(),
 			GasFeeCap:  big.Zero(),
@@ -158,11 +235,11 @@ func execMsgs(t *testing.T, addr address.Address) []types.Message {
 	}
 }
 
-func lockedStates(t *testing.T, caller, other address.Address) map[string]actor.LockedState {
+func lockedStates(t *testing.T, sn1, sn2 address.SubnetID, caller, other address.Address) map[string]actor.LockedState {
 	c1, _ := abi.CidBuilder.Sum([]byte("test1"))
 	c2, _ := abi.CidBuilder.Sum([]byte("test2"))
 	return map[string]actor.LockedState{
-		caller.String(): {From: address.SubnetID("test1"), Cid: c1.String()},
-		other.String():  {From: address.SubnetID("tes2"), Cid: c2.String()},
+		caller.String(): {From: sn1, Cid: c1.String()},
+		other.String():  {From: sn2, Cid: c2.String()},
 	}
 }

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
@@ -240,8 +240,12 @@ func lockedStates(t *testing.T, sn1, sn2 address.SubnetID, caller, other address
 	c2, _ := abi.CidBuilder.Sum([]byte("test2"))
 	act1 := tutil.NewIDAddr(t, 900)
 	act2 := tutil.NewIDAddr(t, 901)
+	addr1, err := address.NewHAddress(sn1, caller)
+	require.NoError(t, err)
+	addr2, err := address.NewHAddress(sn2, other)
+	require.NoError(t, err)
 	return map[string]actor.LockedState{
-		caller.String(): {From: sn1, Cid: c1.String(), Actor: act1},
-		other.String():  {From: sn2, Cid: c2.String(), Actor: act2},
+		addr1.String(): {Cid: c1.String(), Actor: act1},
+		addr2.String(): {Cid: c2.String(), Actor: act2},
 	}
 }

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
@@ -238,8 +238,10 @@ func execMsgs(t *testing.T, addr address.Address) []types.Message {
 func lockedStates(t *testing.T, sn1, sn2 address.SubnetID, caller, other address.Address) map[string]actor.LockedState {
 	c1, _ := abi.CidBuilder.Sum([]byte("test1"))
 	c2, _ := abi.CidBuilder.Sum([]byte("test2"))
+	act1 := tutil.NewIDAddr(t, 900)
+	act2 := tutil.NewIDAddr(t, 901)
 	return map[string]actor.LockedState{
-		caller.String(): {From: sn1, Cid: c1.String()},
-		other.String():  {From: sn2, Cid: c2.String()},
+		caller.String(): {From: sn1, Cid: c1.String(), Actor: act1},
+		other.String():  {From: sn2, Cid: c2.String(), Actor: act2},
 	}
 }

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic_test.go
@@ -27,6 +27,8 @@ func TestAtomicExec(t *testing.T) {
 	h.constructAndVerify(rt)
 	caller := tutil.NewIDAddr(t, 101)
 	other := tutil.NewIDAddr(t, 102)
+	callerSecp := tutil.NewSECP256K1Addr(h.t, caller.String())
+	otherSecp := tutil.NewSECP256K1Addr(h.t, other.String())
 
 	snAddr1 := tutil.NewIDAddr(t, 1000)
 	sn1 := h.registerSubnet(rt, address.RootSubnet, snAddr1)
@@ -34,12 +36,16 @@ func TestAtomicExec(t *testing.T) {
 	sn2 := h.registerSubnet(rt, address.RootSubnet, snAddr2)
 
 	t.Log("init new atomic execution")
-	rt.SetCaller(caller, builtin.AccountActorCodeID)
-	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
 	params := &actor.AtomicExecParams{
 		Msgs:   execMsgs(t, other),
 		Inputs: lockedStates(t, sn1, sn2, caller, other),
 	}
+	// NOTE: The order of this expectSends can potentially make this test flaky according to the order
+	// in which the map of addresses of params is read. This can be fix and is not critical.
+	rt.ExpectSend(caller, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &callerSecp, exitcode.Ok)
+	rt.ExpectSend(other, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &otherSecp, exitcode.Ok)
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
 	ret := rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
 	st := getState(rt)
 	execCid := ret.(*atomic.LockedOutput).Cid
@@ -66,17 +72,21 @@ func TestAtomicExec(t *testing.T) {
 		Cid:    execCid.String(),
 		Output: *output,
 	}
+	rt.ExpectSend(caller, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &callerSecp, exitcode.Ok)
 	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecInitialized)
 
 	t.Log("fail if resubmission or caller not involved")
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectSend(caller, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &callerSecp, exitcode.Ok)
 	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	})
 	stranger := tutil.NewIDAddr(t, 103)
+	strangerSecp := tutil.NewSECP256K1Addr(h.t, stranger.String())
 	rt.SetCaller(stranger, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectSend(stranger, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &strangerSecp, exitcode.Ok)
 	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	})
@@ -84,6 +94,7 @@ func TestAtomicExec(t *testing.T) {
 	t.Log("submitting the wrong output fails")
 	rt.SetCaller(other, builtin.AccountActorCodeID)
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectSend(other, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &otherSecp, exitcode.Ok)
 	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 		c, _ := abi.CidBuilder.Sum([]byte("test1"))
 		output, err := atomic.WrapLockableState(&replace.Owners{M: map[string]cid.Cid{other.String(): c}})
@@ -97,12 +108,19 @@ func TestAtomicExec(t *testing.T) {
 
 	t.Log("execution succeeds and no new submissions accepted")
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectSend(other, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &otherSecp, exitcode.Ok)
 	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecSuccess)
 	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	rt.ExpectSend(other, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &otherSecp, exitcode.Ok)
 	rt.ExpectAbort(exitcode.ErrIllegalArgument, func() {
 		rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
 	})
+	st = getState(rt)
+	exec, found, err = st.GetAtomicExec(adt.AsStore(rt), execCid)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, exec.Status, actor.ExecSuccess)
 
 	t.Log("check propagation messages in top-down message")
 	sh, found := h.getSubnet(rt, sn1)
@@ -113,7 +131,7 @@ func TestAtomicExec(t *testing.T) {
 	exp, err := address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
 	require.NoError(t, err)
 	require.Equal(h.t, msg.From, exp)
-	exp, err = address.NewHAddress(sn1, other)
+	exp, err = address.NewHAddress(sn1, act1(t))
 	require.NoError(t, err)
 	require.Equal(h.t, msg.To, exp)
 	require.Equal(h.t, msg.Method, atomic.MethodUnlock)
@@ -126,7 +144,7 @@ func TestAtomicExec(t *testing.T) {
 	exp, err = address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
 	require.NoError(t, err)
 	require.Equal(h.t, msg.From, exp)
-	exp, err = address.NewHAddress(sn2, other)
+	exp, err = address.NewHAddress(sn2, act2(t))
 	require.NoError(t, err)
 	require.Equal(h.t, msg.To, exp)
 	require.Equal(h.t, msg.Method, atomic.MethodUnlock)
@@ -140,6 +158,38 @@ func TestAtomicExec(t *testing.T) {
 	enc, err := actors.SerializeParams(uparams)
 	require.NoError(t, err)
 	require.Equal(t, enc, msg.Params)
+
+	t.Log("Init new execution and list atomic executions for caller")
+	params2 := &actor.AtomicExecParams{
+		Msgs:   execMsgs(t, stranger),
+		Inputs: lockedStates(t, sn1, sn2, caller, stranger),
+	}
+	// NOTE: The order of this expectSends can potentially make this test flaky according to the order
+	// in which the map of addresses of params is read. This can be fix and is not critical.
+	rt.ExpectSend(caller, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &callerSecp, exitcode.Ok)
+	rt.ExpectSend(stranger, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &strangerSecp, exitcode.Ok)
+	rt.SetCaller(caller, builtin.AccountActorCodeID)
+	rt.ExpectValidateCallerType(builtin.AccountActorCodeID)
+	ret = rt.Call(h.SubnetCoordActor.InitAtomicExec, params2)
+	st = getState(rt)
+	execCid2 := ret.(*atomic.LockedOutput).Cid
+	exec, found, err = st.GetAtomicExec(adt.AsStore(rt), execCid)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, &exec.Params, params)
+	require.Equal(t, exec.Status, actor.ExecSuccess)
+	exec2, found, err := st.GetAtomicExec(adt.AsStore(rt), execCid2)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, &exec2.Params, params2)
+	require.Equal(t, exec2.Status, actor.ExecInitialized)
+
+	m, err := st.ListExecs(rt.AdtStore(), callerSecp)
+	require.NoError(t, err)
+	require.Equal(t, len(m), 2)
+	require.Equal(t, m[execCid].Params, exec.Params)
+	require.Equal(t, m[execCid2].Params, exec2.Params)
+
 }
 
 func TestAbort(t *testing.T) {
@@ -149,6 +199,8 @@ func TestAbort(t *testing.T) {
 	h.constructAndVerify(rt)
 	caller := tutil.NewIDAddr(t, 101)
 	other := tutil.NewIDAddr(t, 102)
+	callerSecp := tutil.NewSECP256K1Addr(h.t, caller.String())
+	otherSecp := tutil.NewSECP256K1Addr(h.t, other.String())
 
 	snAddr1 := tutil.NewIDAddr(t, 1000)
 	sn1 := h.registerSubnet(rt, address.RootSubnet, snAddr1)
@@ -162,6 +214,8 @@ func TestAbort(t *testing.T) {
 		Msgs:   execMsgs(t, other),
 		Inputs: lockedStates(t, sn1, sn2, caller, other),
 	}
+	rt.ExpectSend(caller, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &callerSecp, exitcode.Ok)
+	rt.ExpectSend(other, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &otherSecp, exitcode.Ok)
 	ret := rt.Call(h.SubnetCoordActor.InitAtomicExec, params)
 	st := getState(rt)
 	execCid := ret.(*atomic.LockedOutput).Cid
@@ -178,8 +232,15 @@ func TestAbort(t *testing.T) {
 		Cid:   execCid.String(),
 		Abort: true,
 	}
+	rt.ExpectSend(caller, builtin.MethodsAccount.PubkeyAddress, nil, big.Zero(), &callerSecp, exitcode.Ok)
 	ret = rt.Call(h.SubnetCoordActor.SubmitAtomicExec, oparams)
+	st = getState(rt)
 	require.Equal(t, ret.(*actor.SubmitOutput).Status, actor.ExecAborted)
+	exec, found, err = st.GetAtomicExec(adt.AsStore(rt), execCid)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, &exec.Params, params)
+	require.Equal(t, exec.Status, actor.ExecAborted)
 
 	t.Log("check propagation messages in top-down message")
 	sh, found := h.getSubnet(rt, sn1)
@@ -190,7 +251,7 @@ func TestAbort(t *testing.T) {
 	exp, err := address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
 	require.NoError(t, err)
 	require.Equal(h.t, msg.From, exp)
-	exp, err = address.NewHAddress(sn1, other)
+	exp, err = address.NewHAddress(sn1, act1(t))
 	require.NoError(t, err)
 	require.Equal(h.t, msg.To, exp)
 	require.Equal(h.t, msg.Method, atomic.MethodAbort)
@@ -203,7 +264,7 @@ func TestAbort(t *testing.T) {
 	exp, err = address.NewHAddress(address.RootSubnet, builtin.SystemActorAddr)
 	require.NoError(t, err)
 	require.Equal(h.t, msg.From, exp)
-	exp, err = address.NewHAddress(sn2, other)
+	exp, err = address.NewHAddress(sn2, act2(t))
 	require.NoError(t, err)
 
 	require.Equal(h.t, msg.To, exp)
@@ -235,17 +296,23 @@ func execMsgs(t *testing.T, addr address.Address) []types.Message {
 	}
 }
 
+func act1(t *testing.T) address.Address {
+	return tutil.NewIDAddr(t, 900)
+}
+
+func act2(t *testing.T) address.Address {
+	return tutil.NewIDAddr(t, 901)
+}
+
 func lockedStates(t *testing.T, sn1, sn2 address.SubnetID, caller, other address.Address) map[string]actor.LockedState {
 	c1, _ := abi.CidBuilder.Sum([]byte("test1"))
 	c2, _ := abi.CidBuilder.Sum([]byte("test2"))
-	act1 := tutil.NewIDAddr(t, 900)
-	act2 := tutil.NewIDAddr(t, 901)
 	addr1, err := address.NewHAddress(sn1, caller)
 	require.NoError(t, err)
 	addr2, err := address.NewHAddress(sn2, other)
 	require.NoError(t, err)
 	return map[string]actor.LockedState{
-		addr1.String(): {Cid: c1.String(), Actor: act1},
-		addr2.String(): {Cid: c2.String(), Actor: act2},
+		addr1.String(): {Cid: c1.String(), Actor: act1(t)},
+		addr2.String(): {Cid: c2.String(), Actor: act2(t)},
 	}
 }

--- a/chain/consensus/hierarchical/actors/sca/sca_state.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_state.go
@@ -82,6 +82,9 @@ type SCAState struct {
 	// Keep track of the next nonce of the message to be applied.
 	AppliedBottomUpNonce uint64
 	AppliedTopDownNonce  uint64
+
+	// Atomic execution state
+	AtomicExecRegistry cid.Cid // HAMT[cid]
 }
 
 func ConstructSCAState(store adt.Store, params *ConstructorParams) (*SCAState, error) {
@@ -94,6 +97,10 @@ func ConstructSCAState(store adt.Store, params *ConstructorParams) (*SCAState, e
 		return nil, xerrors.Errorf("failed to create empty map: %w", err)
 	}
 	emptyMsgsMetaMapCid, err := adt.StoreEmptyMap(store, builtin.DefaultHamtBitwidth)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to create empty map: %w", err)
+	}
+	emptyAtomicMapCid, err := adt.StoreEmptyMap(store, builtin.DefaultHamtBitwidth)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create empty map: %w", err)
 	}
@@ -119,6 +126,7 @@ func ConstructSCAState(store adt.Store, params *ConstructorParams) (*SCAState, e
 		CheckMsgsRegistry:    emptyMsgsMetaMapCid,
 		BottomUpMsgsMeta:     emptyBottomUpMsgsAMT,
 		AppliedBottomUpNonce: MaxNonce, // We need inital nonce+1 to be 0 due to how msgs are applied.
+		AtomicExecRegistry:   emptyAtomicMapCid,
 	}, nil
 }
 

--- a/chain/consensus/hierarchical/actors/sca/sca_state.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_state.go
@@ -84,7 +84,7 @@ type SCAState struct {
 	AppliedTopDownNonce  uint64
 
 	// Atomic execution state
-	AtomicExecRegistry cid.Cid // HAMT[cid]
+	AtomicExecRegistry cid.Cid // HAMT[cid]AtomicExec
 }
 
 func ConstructSCAState(store adt.Store, params *ConstructorParams) (*SCAState, error) {

--- a/chain/consensus/hierarchical/actors/sca/sca_test.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_test.go
@@ -350,7 +350,7 @@ func verifyEmptyMap(t testing.TB, rt *mock.Runtime, cid cid.Cid) {
 	assert.Empty(t, keys)
 }
 
-func (h *shActorHarness) registerSubnet(rt *mock.Runtime, parent address.SubnetID, snAddr address.Address) {
+func (h *shActorHarness) registerSubnet(rt *mock.Runtime, parent address.SubnetID, snAddr address.Address) address.SubnetID {
 	h.t.Log("register new subnet successfully")
 	// Send 2FIL of stake
 	value := abi.NewTokenAmount(2e18)
@@ -368,6 +368,7 @@ func (h *shActorHarness) registerSubnet(rt *mock.Runtime, parent address.SubnetI
 	require.Equal(h.t, res.ID, shid.String())
 	rt.Verify()
 	h.sn = shid
+	return shid
 }
 
 func getState(rt *mock.Runtime) *actor.SCAState {

--- a/chain/consensus/hierarchical/atomic/lock.go
+++ b/chain/consensus/hierarchical/atomic/lock.go
@@ -85,6 +85,10 @@ func WrapUnlockParams(params *LockParams, out LockableState) (*UnlockParams, err
 	return &UnlockParams{params, buf.Bytes()}, nil
 }
 
+func WrapSerializedUnlockParams(params *LockParams, out []byte) (*UnlockParams, error) {
+	return &UnlockParams{params, out}, nil
+}
+
 func UnwrapUnlockParams(params *UnlockParams, out LockableState) error {
 	return out.UnmarshalCBOR(bytes.NewReader(params.State))
 }

--- a/chain/consensus/hierarchical/atomic/lock.go
+++ b/chain/consensus/hierarchical/atomic/lock.go
@@ -125,7 +125,7 @@ func UnwrapMergeParams(params *MergeParams, out LockableState) error {
 func ValidateIfLocked(states ...*LockedState) error {
 	for _, s := range states {
 		if s.IsLocked() {
-			return xerrors.Errorf("abort. One of the state or more are locked")
+			return xerrors.Errorf("abort. One of the states or more are locked")
 		}
 	}
 	return nil

--- a/chain/consensus/hierarchical/atomic/lock_test.go
+++ b/chain/consensus/hierarchical/atomic/lock_test.go
@@ -102,7 +102,7 @@ var _ atomic.LockableState = &SampleState{}
 
 var lengthBufSampleState = []byte{129}
 
-func (t *SampleState) Merge(other atomic.LockableState) error {
+func (t *SampleState) Merge(other atomic.LockableState, output bool) error {
 	// Naïve merging with the other value.
 	// It's up to the developer to chose the best way
 	// to merge

--- a/chain/consensus/hierarchical/subnet/manager/atomic.go
+++ b/chain/consensus/hierarchical/subnet/manager/atomic.go
@@ -222,15 +222,13 @@ func (s *SubnetMgr) ComputeAndSubmitExec(ctx context.Context, wallet address.Add
 	// get heaviest tipset
 	ts := execApi.ChainAPI.Chain.GetHeaviestTipSet()
 
-	// FIXME: Make this state to populate configurable.
-	actSt := &replace.ReplaceState{}
-	err = exec.ComputeAtomicOutput(ctx, execApi.StateManager, ts, toActor, actSt, locked, ae.Params.Msgs)
+	output, err := exec.ComputeAtomicOutput(ctx, execApi.StateManager, ts, toActor, locked, ae.Params.Msgs)
 	if err != nil {
 		return sca.ExecUndefState, err
 	}
 
 	// FIXME: Make output state configurable
-	spm := &sca.SubmitExecParams{Cid: execID.String(), Output: *actSt.Owners}
+	spm := &sca.SubmitExecParams{Cid: execID.String(), Output: *output}
 
 	// submit output
 	serparams, err := actors.SerializeParams(spm)

--- a/chain/consensus/hierarchical/subnet/manager/atomic.go
+++ b/chain/consensus/hierarchical/subnet/manager/atomic.go
@@ -1,0 +1,59 @@
+package subnetmgr
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+)
+
+func (s *SubnetMgr) LockState(
+	ctx context.Context, wallet address.Address, actor address.Address,
+	subnet address.SubnetID, method abi.MethodNum) (cid.Cid, error) {
+
+	sapi, err := s.GetSubnetAPI(subnet)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	// FIXME: Disregarding params to lock for now
+	lpm, err := atomic.WrapSerializedParams(method, []byte{})
+	if err != nil {
+		return cid.Undef, err
+	}
+	serparams, err := actors.SerializeParams(lpm)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed serializing init actor params: %s", err)
+	}
+
+	smsg, aerr := sapi.MpoolPushMessage(ctx, &types.Message{
+		To:     actor,
+		From:   wallet,
+		Value:  abi.NewTokenAmount(0),
+		Method: atomic.MethodLock,
+		Params: serparams,
+	}, nil)
+	if aerr != nil {
+		return cid.Undef, aerr
+	}
+
+	msg := smsg.Cid()
+	mw, aerr := sapi.StateWaitMsg(ctx, msg, build.MessageConfidence, api.LookbackNoLimit, true)
+	if aerr != nil {
+		return cid.Undef, aerr
+	}
+
+	r := &atomic.LockedOutput{}
+	if err := r.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)); err != nil {
+		return cid.Undef, xerrors.Errorf("error unmarshalling locked output: %s", err)
+	}
+	return r.Cid, nil
+}

--- a/chain/consensus/hierarchical/subnet/manager/atomic.go
+++ b/chain/consensus/hierarchical/subnet/manager/atomic.go
@@ -7,12 +7,16 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
 	"golang.org/x/xerrors"
 )
 
@@ -59,15 +63,14 @@ func (s *SubnetMgr) LockState(
 	return r.Cid, nil
 }
 
-// XXX: TODO: Add inputs, how to pass the input to init the execution?
 func (s *SubnetMgr) InitAtomicExec(
-	ctx context.Context, wallet address.Address, inputs []sca.LockedState,
-	msgs []types.Message, method abi.MethodNum) (cid.Cid, error) {
+	ctx context.Context, wallet address.Address, inputs map[string]sca.LockedState,
+	msgs []types.Message) (cid.Cid, error) {
 
 	// Compute common parent of subnets.
-	cp := inputs[0].From
-	for _, i := range inputs[1:] {
-		cp, _ = cp.CommonParent(i.From)
+	cp, err := sca.GetCommonParentForExec(inputs)
+	if err != nil {
+		return cid.Undef, err
 	}
 
 	sapi, err := s.GetSubnetAPI(cp)
@@ -82,10 +85,10 @@ func (s *SubnetMgr) InitAtomicExec(
 	}
 
 	smsg, aerr := sapi.MpoolPushMessage(ctx, &types.Message{
-		To:     actor,
+		To:     hierarchical.SubnetCoordActorAddr,
 		From:   wallet,
 		Value:  abi.NewTokenAmount(0),
-		Method: atomic.MethodLock,
+		Method: sca.Methods.InitAtomicExec,
 		Params: serparams,
 	}, nil)
 	if aerr != nil {
@@ -103,4 +106,154 @@ func (s *SubnetMgr) InitAtomicExec(
 		return cid.Undef, xerrors.Errorf("error unmarshalling locked output: %s", err)
 	}
 	return r.Cid, nil
+}
+
+func (s *SubnetMgr) ListAtomicExecs(
+	ctx context.Context, id address.SubnetID, addr address.Address) ([]*sca.AtomicExec, error) {
+
+	// TODO: Think a bit deeper the locking strategy for subnets.
+	s.lk.RLock()
+	defer s.lk.RUnlock()
+
+	api, err := s.GetSubnetAPI(id)
+	if err != nil {
+		return nil, err
+	}
+
+	scaAct, err := api.StateGetActor(ctx, hierarchical.SubnetCoordActorAddr, types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+
+	var st sca.SCAState
+	pbs := blockstore.NewAPIBlockstore(api)
+	pcst := cbor.NewCborStore(pbs)
+	if err := pcst.Get(ctx, scaAct.Head, &st); err != nil {
+		return nil, err
+	}
+	pstore := adt.WrapStore(ctx, pcst)
+	m, err := st.ListExecs(pstore, addr)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*sca.AtomicExec, 0)
+	for _, v := range m {
+		out = append(out, &v)
+	}
+	return out, nil
+}
+
+func getAtomicExec(ctx context.Context, api *API, c cid.Cid) (*sca.AtomicExec, bool, error) {
+	var st sca.SCAState
+	scaAct, err := api.StateGetActor(ctx, hierarchical.SubnetCoordActorAddr, types.EmptyTSK)
+	if err != nil {
+		return nil, false, err
+	}
+	pbs := blockstore.NewAPIBlockstore(api)
+	pcst := cbor.NewCborStore(pbs)
+	if err := pcst.Get(ctx, scaAct.Head, &st); err != nil {
+		return nil, false, err
+	}
+	pstore := adt.WrapStore(ctx, pcst)
+	return st.GetAtomicExec(pstore, c)
+}
+
+func (s *SubnetMgr) ComputeAndSubmitExec(ctx context.Context, wallet address.Address,
+	id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error) {
+
+	panic("not implemented yet")
+	/*
+		sapi := s.getAPI(id)
+		if sapi == nil {
+			return sca.ExecUndefState, xerrors.Errorf("not syncing with subnet")
+		}
+		// Check if the exec exists.
+		ae, found, err := getAtomicExec(ctx, sapi, execID)
+		if err != nil {
+			return sca.ExecUndefState, err
+		}
+		if !found {
+			return sca.ExecUndefState, xerrors.Errorf("execution not found in subnet for cid")
+		}
+			// FIXME: Make this state to populate configurable.
+			actSt := replace.ReplaceState{}
+			// TODO: Get locked states for the other subnets for the execution.
+			err = exec.ComputeAtomicOutput(ctx, sapi.StateManager, actSt, lockedm, ae.Params.Msgs)
+			if err != nil {
+				return sca.ExecUndefState, err
+			}
+
+			spm := &sca.SubmitExecParams{Cid: execID.String(), Output: output}
+			serparams, err := actors.SerializeParams(spm)
+			if err != nil {
+				return sca.ExecUndefState, xerrors.Errorf("failed serializing init actor params: %s", err)
+			}
+
+			smsg, aerr := sapi.MpoolPushMessage(ctx, &types.Message{
+				To:     hierarchical.SubnetCoordActorAddr,
+				From:   wallet,
+				Value:  abi.NewTokenAmount(0),
+				Method: sca.Methods.SubmitAtomicExec,
+				Params: serparams,
+			}, nil)
+			if aerr != nil {
+				return sca.ExecUndefState, aerr
+			}
+
+			msg := smsg.Cid()
+			mw, aerr := sapi.StateWaitMsg(ctx, msg, build.MessageConfidence, api.LookbackNoLimit, true)
+			if aerr != nil {
+				return sca.ExecUndefState, aerr
+			}
+
+			r := &sca.SubmitOutput{}
+			if err := r.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)); err != nil {
+				return sca.ExecUndefState, xerrors.Errorf("error unmarshalling output: %s", err)
+			}
+			return r.Status, nil
+	*/
+}
+func (s *SubnetMgr) AbortAtomicExec(ctx context.Context, wallet address.Address,
+	id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error) {
+
+	sapi := s.getAPI(id)
+	if sapi == nil {
+		return sca.ExecUndefState, xerrors.Errorf("not syncing with subnet")
+	}
+	// Check if the exec exists.
+	_, found, err := getAtomicExec(ctx, sapi, execID)
+	if err != nil {
+		return sca.ExecUndefState, err
+	}
+	if !found {
+		return sca.ExecUndefState, xerrors.Errorf("execution not found in subnet for cid")
+	}
+	spm := &sca.SubmitExecParams{Cid: execID.String(), Abort: true}
+	serparams, err := actors.SerializeParams(spm)
+	if err != nil {
+		return sca.ExecUndefState, xerrors.Errorf("failed serializing init actor params: %s", err)
+	}
+
+	smsg, aerr := sapi.MpoolPushMessage(ctx, &types.Message{
+		To:     hierarchical.SubnetCoordActorAddr,
+		From:   wallet,
+		Value:  abi.NewTokenAmount(0),
+		Method: sca.Methods.SubmitAtomicExec,
+		Params: serparams,
+	}, nil)
+	if aerr != nil {
+		return sca.ExecUndefState, aerr
+	}
+
+	msg := smsg.Cid()
+	mw, aerr := sapi.StateWaitMsg(ctx, msg, build.MessageConfidence, api.LookbackNoLimit, true)
+	if aerr != nil {
+		return sca.ExecUndefState, aerr
+	}
+
+	r := &sca.SubmitOutput{}
+	if err := r.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)); err != nil {
+		return sca.ExecUndefState, xerrors.Errorf("error unmarshalling output: %s", err)
+	}
+	return r.Status, nil
 }

--- a/chain/consensus/hierarchical/subnet/manager/atomic.go
+++ b/chain/consensus/hierarchical/subnet/manager/atomic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/atomic"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
@@ -30,6 +31,52 @@ func (s *SubnetMgr) LockState(
 		return cid.Undef, err
 	}
 	serparams, err := actors.SerializeParams(lpm)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("failed serializing init actor params: %s", err)
+	}
+
+	smsg, aerr := sapi.MpoolPushMessage(ctx, &types.Message{
+		To:     actor,
+		From:   wallet,
+		Value:  abi.NewTokenAmount(0),
+		Method: atomic.MethodLock,
+		Params: serparams,
+	}, nil)
+	if aerr != nil {
+		return cid.Undef, aerr
+	}
+
+	msg := smsg.Cid()
+	mw, aerr := sapi.StateWaitMsg(ctx, msg, build.MessageConfidence, api.LookbackNoLimit, true)
+	if aerr != nil {
+		return cid.Undef, aerr
+	}
+
+	r := &atomic.LockedOutput{}
+	if err := r.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)); err != nil {
+		return cid.Undef, xerrors.Errorf("error unmarshalling locked output: %s", err)
+	}
+	return r.Cid, nil
+}
+
+// XXX: TODO: Add inputs, how to pass the input to init the execution?
+func (s *SubnetMgr) InitAtomicExec(
+	ctx context.Context, wallet address.Address, inputs []sca.LockedState,
+	msgs []types.Message, method abi.MethodNum) (cid.Cid, error) {
+
+	// Compute common parent of subnets.
+	cp := inputs[0].From
+	for _, i := range inputs[1:] {
+		cp, _ = cp.CommonParent(i.From)
+	}
+
+	sapi, err := s.GetSubnetAPI(cp)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	ipm := &sca.AtomicExecParams{Inputs: inputs, Msgs: msgs}
+	serparams, err := actors.SerializeParams(ipm)
 	if err != nil {
 		return cid.Undef, xerrors.Errorf("failed serializing init actor params: %s", err)
 	}

--- a/chain/consensus/hierarchical/subnet/manager/events.go
+++ b/chain/consensus/hierarchical/subnet/manager/events.go
@@ -58,7 +58,7 @@ func (s *SubnetMgr) listenSubnetEvents(ctx context.Context, sh *Subnet) {
 	root := true
 
 	// If subnet is nil, we are listening from the root chain.
-	// TODO: Revisit this, there is probably a most elegant way to
+	// TODO: Revisit this, there is probably a more elegant way to
 	// do this.
 	if sh != nil {
 		root = false

--- a/chain/consensus/hierarchical/subnet/manager/manager.go
+++ b/chain/consensus/hierarchical/subnet/manager/manager.go
@@ -655,7 +655,7 @@ func (s *SubnetMgr) isRoot(id address.SubnetID) bool {
 }
 
 func (s *SubnetMgr) getAPI(id address.SubnetID) *API {
-	if s.isRoot(id) {
+	if s.isRoot(id) || id == address.RootSubnet {
 		return s.api
 	}
 	sh, ok := s.subnets[id]

--- a/chain/consensus/hierarchical/subnet/resolver/resolver.go
+++ b/chain/consensus/hierarchical/subnet/resolver/resolver.go
@@ -562,7 +562,6 @@ func (r *Resolver) WaitLockedStateResolved(ctx context.Context, c cid.Cid, from 
 				out <- xerrors.Errorf("context timeout")
 				return
 			default:
-				// Check if crossMsg fully resolved.
 				_, resolved, err = r.ResolveLockedState(ctx, c, address.SubnetID(from), actor)
 				if err != nil {
 					out <- err

--- a/chain/consensus/hierarchical/subnet/resolver/resolver.go
+++ b/chain/consensus/hierarchical/subnet/resolver/resolver.go
@@ -261,7 +261,7 @@ func (v *Validator) Validate(ctx context.Context, pid peer.ID, msg *pubsub.Messa
 	// Process the resolveMsg, record error, and return gossipsub validation status.
 	sub, err := v.r.processResolveMsg(ctx, v.submgr, rmsg)
 	if err != nil {
-		log.Errorf("error processing resolve message: %s", err)
+		log.Errorf("error processing resolve message: %w", err)
 		return sub
 	}
 
@@ -367,7 +367,7 @@ func (r *Resolver) processPullLocked(submgr subnet.SubnetMgr, rmsg *ResolveMsg) 
 	// FIXME: Make this configurable
 	lstate, found, err := r.getLockedStateFromActor(context.TODO(), submgr, rmsg)
 	if err != nil {
-		return pubsub.ValidationIgnore, err
+		return pubsub.ValidationIgnore, xerrors.Errorf("error geting locked state from actor", err)
 	}
 	if !found {
 		// Reject instead of ignore. Someone may be trying to spam us with

--- a/cmd/eudico/atomic-exec.go
+++ b/cmd/eudico/atomic-exec.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/actors/builtin"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
+	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/xerrors"
 )
@@ -16,12 +22,16 @@ var atomicExecCmds = &cli.Command{
 	Subcommands: []*cli.Command{
 		listAtomicExec,
 		lockStateCmd,
+		formatMsgCmd,
+		initExecCmd,
+		abortCmd,
 	},
 }
 
 var listAtomicExec = &cli.Command{
-	Name:  "list-execs",
-	Usage: "list pending atomic executions for address",
+	Name:      "list-execs",
+	Usage:     "list pending atomic executions for address",
+	ArgsUsage: "[<target address>]",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:  "subnet",
@@ -30,31 +40,40 @@ var listAtomicExec = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		// api, closer, err := lcli.GetFullNodeAPI(cctx)
-		// if err != nil {
-		//         return err
-		// }
-		// defer closer()
-		// ctx := lcli.ReqContext(cctx)
-		//
-		// // If subnet not set use root. Otherwise, use flag value
-		// var subnet string
-		// if cctx.String("subnet") != address.RootSubnet.String() {
-		//         subnet = cctx.String("subnet")
-		// }
-		//
-		// chs, err := api.ListCheckpoints(ctx, address.SubnetID(subnet), cctx.Int("num"))
-		// if err != nil {
-		//         return err
-		// }
-		// for _, ch := range chs {
-		//         chcid, _ := ch.Cid()
-		//         prev, _ := ch.PreviousCheck()
-		//         lc := len(ch.CrossMsgs()) > 0
-		//         fmt.Printf("epoch: %d - cid=%s, previous=%v, childs=%v, crossmsgs=%v\n", ch.Epoch(), chcid, prev, ch.LenChilds(), lc)
-		// }
-		// return nil
-		panic("not implemented yet")
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+		ctx := lcli.ReqContext(cctx)
+
+		if cctx.Args().Len() != 1 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("expects as argument the target address to get list of executions from"))
+		}
+		// If subnet not set use root. Otherwise, use flag value
+		subnet := address.RootSubnet
+		if cctx.String("subnet") != address.RootSubnet.String() {
+			subnet = address.SubnetID(cctx.String("subnet"))
+		}
+		addr, err := address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return err
+		}
+		execs, err := api.ListAtomicExecs(ctx, subnet, addr)
+		if err != nil {
+			return err
+		}
+		if len(execs) == 0 {
+			fmt.Printf("no pending executions in subnet\n")
+		}
+		for _, ex := range execs {
+			c, err := ex.Params.Cid()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("cid: %s - status=%s, submitted=%v\n", c, sca.ExecStatusStr[ex.Status], len(ex.Submitted))
+		}
+		return nil
 	},
 }
 
@@ -121,7 +140,305 @@ var lockStateCmd = &cli.Command{
 			return xerrors.Errorf("Error locking state: %s", err)
 		}
 		fmt.Fprintf(cctx.App.Writer, "Successfully locked state with Cid: %s\n", c)
-		fmt.Fprintf(cctx.App.Writer, "Ready to exchange to perform atomic execution for actor from: %s for method %v\n", subnet, method)
+		fmt.Fprintf(cctx.App.Writer, "Ready to exchange locked state to perform atomic execution for actor from: %s for method %v\n", subnet, method)
+		return nil
+	},
+}
+
+var abortCmd = &cli.Command{
+	Name:      "abort-exec",
+	Usage:     "Abort atomic execution",
+	ArgsUsage: "[<cid of exec>]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account to send message from",
+		},
+		&cli.StringFlag{
+			Name:  "subnet",
+			Usage: "specify the id of the subnet",
+			Value: address.RootSubnet.String(),
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.Args().Len() != 1 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("expects cid of execution to abort as input"))
+		}
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		// Try to get default address first
+		addr, _ := api.WalletDefaultAddress(ctx)
+		if from := cctx.String("from"); from != "" {
+			addr, err = address.NewFromString(from)
+			if err != nil {
+				return err
+			}
+		}
+
+		subnet := address.RootSubnet
+		if cctx.String("subnet") != address.RootSubnet.String() {
+			subnet = address.SubnetID(cctx.String("subnet"))
+		}
+		idExec, err := cid.Parse(cctx.Args().Get(0))
+		if err != nil {
+			return err
+		}
+		state, err := api.AbortAtomicExec(ctx, addr, subnet, idExec)
+		if err != nil {
+			return xerrors.Errorf("Error aborting execution: %s", err)
+		}
+		fmt.Fprintf(cctx.App.Writer, "Successfully aborted execution: %s\n", sca.ExecStatusStr[state])
+		return nil
+	},
+}
+var initExecCmd = &cli.Command{
+	Name:      "init-exec",
+	Usage:     "Signal initialization of atomic execution to the right subnet",
+	ArgsUsage: "[]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account to send message from",
+		},
+		&cli.StringSliceFlag{
+			Name:  "addr",
+			Usage: "specify address involved in execution",
+			Value: &cli.StringSlice{},
+		},
+		&cli.StringSliceFlag{
+			Name:  "actor",
+			Usage: "specify list of actors involved actors in the same order of the addresses provided",
+			Value: &cli.StringSlice{},
+		},
+		&cli.StringSliceFlag{
+			Name:  "locked",
+			Usage: "specify the list of locked states in the order address have been provided",
+			Value: &cli.StringSlice{},
+		},
+		&cli.StringSliceFlag{
+			Name:  "msg",
+			Usage: "list of messages for the atomic execution",
+			Value: &cli.StringSlice{},
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.Args().Len() != 0 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("expects no arguments as input, just flags"))
+		}
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		// Try to get default address first
+		wallet, _ := api.WalletDefaultAddress(ctx)
+		if from := cctx.String("from"); from != "" {
+			wallet, err = address.NewFromString(from)
+			if err != nil {
+				return err
+			}
+		}
+
+		addrs := cctx.StringSlice("addr")
+		actors := cctx.StringSlice("actor")
+		locked := cctx.StringSlice("locked")
+		msgs := cctx.StringSlice("msg")
+		if len(addrs) < 2 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("not enough addresses provided for atomic execution"))
+		}
+		if len(actors) != len(addrs) || len(locked) != len(addrs) {
+			return lcli.ShowHelp(cctx, fmt.Errorf("size of actors and/or locked states is not equal to the number of parties involved"))
+		}
+		if len(msgs) == 0 {
+			return xerrors.Errorf("no messages provided for atomic execution")
+		}
+		inputs := make(map[string]sca.LockedState)
+		for i, addr := range addrs {
+			_, err := cid.Decode(locked[i])
+			if err != nil {
+				return xerrors.Errorf("error parsing cid of locked state: %w", err)
+			}
+			actor, err := address.NewFromString(actors[i])
+			if err != nil {
+				return xerrors.Errorf("error parsing actor address: %w", err)
+			}
+			inputs[addr] = sca.LockedState{Cid: locked[i], Actor: actor}
+		}
+		messages := make([]types.Message, len(msgs))
+		for i, m := range msgs {
+			msg := types.Message{}
+			err = json.Unmarshal([]byte(m), &msg)
+			if err != nil {
+				return xerrors.Errorf("error unmarshalling mesasge: %w", err)
+			}
+			messages[i] = msg
+		}
+
+		c, err := api.InitAtomicExec(ctx, wallet, inputs, messages)
+		if err != nil {
+			return xerrors.Errorf("Error initializing atomic execution: %s", err)
+		}
+		cp, _ := sca.GetCommonParentForExec(inputs)
+		fmt.Fprintf(cctx.App.Writer, "Successfully initialized atomic execution in subnet %s with Cid: %s\n", cp, c)
+		fmt.Fprintf(cctx.App.Writer, "You can verify and submit the execution locally now.\n")
+		return nil
+	},
+}
+
+var formatMsgCmd = &cli.Command{
+	Name:      "format-msg",
+	Usage:     "Formats a message in a way that can be provided through the command-line to init an atomic exec",
+	ArgsUsage: "[targetAddress] [amount]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account to send funds from",
+		},
+		&cli.StringFlag{
+			Name:  "gas-premium",
+			Usage: "specify gas price to use in AttoFIL",
+			Value: "0",
+		},
+		&cli.StringFlag{
+			Name:  "gas-feecap",
+			Usage: "specify gas fee cap to use in AttoFIL",
+			Value: "0",
+		},
+		&cli.Int64Flag{
+			Name:  "gas-limit",
+			Usage: "specify gas limit",
+			Value: 0,
+		},
+		&cli.Uint64Flag{
+			Name:  "nonce",
+			Usage: "specify the nonce to use",
+			Value: 0,
+		},
+		&cli.Uint64Flag{
+			Name:  "method",
+			Usage: "specify method to invoke",
+			Value: uint64(builtin.MethodSend),
+		},
+		&cli.StringFlag{
+			Name:  "params-json",
+			Usage: "specify invocation parameters in json",
+		},
+		&cli.StringFlag{
+			Name:  "params-hex",
+			Usage: "specify invocation parameters in hex",
+		},
+		&cli.BoolFlag{
+			Name:  "force",
+			Usage: "Deprecated: use global 'force-send'",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		if cctx.IsSet("force") {
+			fmt.Println("'force' flag is deprecated, use global flag 'force-send'")
+		}
+
+		if cctx.Args().Len() != 2 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("'send' expects two arguments, target and amount"))
+		}
+
+		srv, err := lcli.GetFullNodeServices(cctx)
+		if err != nil {
+			return err
+		}
+		defer srv.Close() //nolint:errcheck
+
+		ctx := lcli.ReqContext(cctx)
+		var params lcli.SendParams
+
+		params.To, err = address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return lcli.ShowHelp(cctx, fmt.Errorf("failed to parse target address: %w", err))
+		}
+
+		val, err := types.ParseFIL(cctx.Args().Get(1))
+		if err != nil {
+			return lcli.ShowHelp(cctx, fmt.Errorf("failed to parse amount: %w", err))
+		}
+		params.Val = abi.TokenAmount(val)
+
+		if from := cctx.String("from"); from != "" {
+			addr, err := address.NewFromString(from)
+			if err != nil {
+				return err
+			}
+
+			params.From = addr
+		}
+
+		if cctx.IsSet("gas-premium") {
+			gp, err := types.BigFromString(cctx.String("gas-premium"))
+			if err != nil {
+				return err
+			}
+			params.GasPremium = &gp
+		}
+
+		if cctx.IsSet("gas-feecap") {
+			gfc, err := types.BigFromString(cctx.String("gas-feecap"))
+			if err != nil {
+				return err
+			}
+			params.GasFeeCap = &gfc
+		}
+
+		if cctx.IsSet("gas-limit") {
+			limit := cctx.Int64("gas-limit")
+			params.GasLimit = &limit
+		}
+
+		params.Method = abi.MethodNum(cctx.Uint64("method"))
+
+		if cctx.IsSet("params-json") {
+			decparams, err := srv.DecodeTypedParamsFromJSON(ctx, params.To, params.Method, cctx.String("params-json"))
+			if err != nil {
+				return fmt.Errorf("failed to decode json params: %w", err)
+			}
+			params.Params = decparams
+		}
+		if cctx.IsSet("params-hex") {
+			if params.Params != nil {
+				return fmt.Errorf("can only specify one of 'params-json' and 'params-hex'")
+			}
+			decparams, err := hex.DecodeString(cctx.String("params-hex"))
+			if err != nil {
+				return fmt.Errorf("failed to decode hex params: %w", err)
+			}
+			params.Params = decparams
+		}
+
+		if cctx.IsSet("nonce") {
+			n := cctx.Uint64("nonce")
+			params.Nonce = &n
+		}
+
+		proto, err := srv.MessageForSend(ctx, params)
+		if err != nil {
+			return xerrors.Errorf("creating message prototype: %w", err)
+		}
+
+		b, err := json.Marshal(proto.Message)
+		if err != nil {
+			return xerrors.Errorf("error marshaling message: %w", err)
+		}
+
+		fmt.Fprintf(cctx.App.Writer, "%s\n", string(b))
+
 		return nil
 	},
 }

--- a/cmd/eudico/atomic-exec.go
+++ b/cmd/eudico/atomic-exec.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	lcli "github.com/filecoin-project/lotus/cli"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/xerrors"
+)
+
+var atomicExecCmds = &cli.Command{
+	Name:  "atomic",
+	Usage: "Commands to orchestrate atomic execution between subnets",
+	Subcommands: []*cli.Command{
+		listAtomicExec,
+		lockStateCmd,
+	},
+}
+
+var listAtomicExec = &cli.Command{
+	Name:  "list-execs",
+	Usage: "list pending atomic executions for address",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "subnet",
+			Usage: "specify the id of the subnet to list checkpoints from",
+			Value: address.RootSubnet.String(),
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		// api, closer, err := lcli.GetFullNodeAPI(cctx)
+		// if err != nil {
+		//         return err
+		// }
+		// defer closer()
+		// ctx := lcli.ReqContext(cctx)
+		//
+		// // If subnet not set use root. Otherwise, use flag value
+		// var subnet string
+		// if cctx.String("subnet") != address.RootSubnet.String() {
+		//         subnet = cctx.String("subnet")
+		// }
+		//
+		// chs, err := api.ListCheckpoints(ctx, address.SubnetID(subnet), cctx.Int("num"))
+		// if err != nil {
+		//         return err
+		// }
+		// for _, ch := range chs {
+		//         chcid, _ := ch.Cid()
+		//         prev, _ := ch.PreviousCheck()
+		//         lc := len(ch.CrossMsgs()) > 0
+		//         fmt.Printf("epoch: %d - cid=%s, previous=%v, childs=%v, crossmsgs=%v\n", ch.Epoch(), chcid, prev, ch.LenChilds(), lc)
+		// }
+		// return nil
+		panic("not implemented yet")
+	},
+}
+
+var lockStateCmd = &cli.Command{
+	Name:      "lock-state",
+	Usage:     "Lock state for an actor to init atomic execution",
+	ArgsUsage: "[<actor address>]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account to send message from",
+		},
+		&cli.StringFlag{
+			Name:  "subnet",
+			Usage: "specify the id of the subnet",
+			Value: address.RootSubnet.String(),
+		},
+		&cli.IntFlag{
+			Name:  "method",
+			Usage: "specify actor method for atomic execution",
+			Value: -1,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.Args().Len() != 1 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("expects the actor address for atomic execution as input"))
+		}
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		ctx := lcli.ReqContext(cctx)
+
+		// Try to get default address first
+		addr, _ := api.WalletDefaultAddress(ctx)
+		if from := cctx.String("from"); from != "" {
+			addr, err = address.NewFromString(from)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Atomic execution requires an ancesto. Rootnet has no support for atomic exec.
+		var subnet address.SubnetID
+		if cctx.String("subnet") == address.RootSubnet.String() ||
+			cctx.String("subnet") == "" {
+			return xerrors.Errorf("only subnets with an ancestor can perform atomic executions")
+		}
+		subnet = address.SubnetID(cctx.String("subnet"))
+		actorAddr, err := address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return lcli.ShowHelp(cctx, fmt.Errorf("failed to parse actor address: %w", err))
+		}
+
+		if cctx.Int("method") == -1 {
+			return xerrors.Errorf("Method for atomic execution in actor nof specified")
+		}
+		method := abi.MethodNum(cctx.Int("method"))
+		c, err := api.LockState(ctx, addr, actorAddr, subnet, method)
+		if err != nil {
+			return xerrors.Errorf("Error locking state: %s", err)
+		}
+		fmt.Fprintf(cctx.App.Writer, "Successfully locked state with Cid: %s\n", c)
+		fmt.Fprintf(cctx.App.Writer, "Ready to exchange to perform atomic execution for actor from: %s for method %v\n", subnet, method)
+		return nil
+	},
+}

--- a/cmd/eudico/subnet.go
+++ b/cmd/eudico/subnet.go
@@ -38,6 +38,7 @@ var subnetCmds = &cli.Command{
 		leaveCmd,
 		killCmd,
 		checkpointCmds,
+		atomicExecCmds,
 		fundCmd,
 		releaseCmd,
 		sendCmd,

--- a/cmd/eudico/subnet.go
+++ b/cmd/eudico/subnet.go
@@ -43,6 +43,7 @@ var subnetCmds = &cli.Command{
 		releaseCmd,
 		sendCmd,
 		deployActorCmd,
+		hAddrCmd,
 	},
 }
 
@@ -507,6 +508,34 @@ var releaseCmd = &cli.Command{
 	},
 }
 
+var hAddrCmd = &cli.Command{
+	Name:      "hierarchical-addr",
+	Usage:     "Returns a formatted hierarchical address",
+	ArgsUsage: "[<raw address>]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "subnet",
+			Usage: "specify the id of the subnet",
+			Value: address.RootSubnet.String(),
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.Args().Len() != 1 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("'fund' expects the amount of FILs to inject to subnet, and a set of flags"))
+		}
+		addr, err := address.NewFromString(cctx.Args().Get(0))
+		if err != nil {
+			return err
+		}
+		out, err := address.NewHAddress(address.SubnetID(cctx.String("subnet")), addr)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cctx.App.Writer, "%s\n", out)
+		return nil
+	},
+}
 var fundCmd = &cli.Command{
 	Name:      "fund",
 	Usage:     "Inject new funds to your address in a subnet",

--- a/cmd/eudico/subnet.go
+++ b/cmd/eudico/subnet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	big "github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/actors"
 	"github.com/filecoin-project/lotus/chain/actors/adt"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
@@ -16,6 +17,9 @@ import (
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/lotus/chain/types"
 	lcli "github.com/filecoin-project/lotus/cli"
+	spec_builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/urfave/cli/v2"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -37,6 +41,7 @@ var subnetCmds = &cli.Command{
 		fundCmd,
 		releaseCmd,
 		sendCmd,
+		deployActorCmd,
 	},
 }
 
@@ -641,7 +646,6 @@ var sendCmd = &cli.Command{
 			return lcli.ShowHelp(cctx, fmt.Errorf("failed to parse amount: %w", err))
 		}
 		params.Val = abi.TokenAmount(val)
-
 		if from := cctx.String("from"); from != "" {
 			addr, err := address.NewFromString(from)
 			if err != nil {
@@ -728,6 +732,171 @@ var sendCmd = &cli.Command{
 
 		fmt.Fprintf(cctx.App.Writer, "Successfully send cross-message with cid: %s\n", smsg.Cid())
 		fmt.Fprintf(cctx.App.Writer, "Cross-message should be propagated shortly to the right subnet: %s\n", subnet)
+		return nil
+	},
+}
+
+var deployActorCmd = &cli.Command{
+	Name:      "deploy-actor",
+	Usage:     "Deploy and actor in a subnet. Select right subnet with --subnet-api flag",
+	ArgsUsage: "[actor CodeCid]",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "from",
+			Usage: "optionally specify the account to send funds from",
+		},
+		&cli.StringFlag{
+			Name:  "gas-premium",
+			Usage: "specify gas price to use in AttoFIL",
+			Value: "0",
+		},
+		&cli.StringFlag{
+			Name:  "gas-feecap",
+			Usage: "specify gas fee cap to use in AttoFIL",
+			Value: "0",
+		},
+		&cli.Int64Flag{
+			Name:  "gas-limit",
+			Usage: "specify gas limit",
+			Value: 0,
+		},
+		&cli.Uint64Flag{
+			Name:  "nonce",
+			Usage: "specify the nonce to use",
+			Value: 0,
+		},
+		&cli.StringFlag{
+			Name:  "params-json",
+			Usage: "specify invocation parameters in json",
+		},
+		&cli.StringFlag{
+			Name:  "params-hex",
+			Usage: "specify invocation parameters in hex",
+		},
+		&cli.BoolFlag{
+			Name:  "force",
+			Usage: "Deprecated: use global 'force-send'",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+
+		if cctx.Args().Len() != 1 {
+			return lcli.ShowHelp(cctx, fmt.Errorf("'send' expects the codeCid as first parameter"))
+		}
+		api, closer, err := lcli.GetFullNodeAPI(cctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		srv, err := lcli.GetFullNodeServices(cctx)
+		if err != nil {
+			return err
+		}
+		defer srv.Close() //nolint:errcheck
+
+		ctx := lcli.ReqContext(cctx)
+		var params lcli.SendParams
+
+		params.From, _ = api.WalletDefaultAddress(ctx)
+		if from := cctx.String("from"); from != "" {
+			addr, err := address.NewFromString(from)
+			if err != nil {
+				return err
+			}
+
+			params.From = addr
+		}
+
+		zero := big.Zero()
+		params.GasPremium = &zero
+		if cctx.IsSet("gas-premium") {
+			gp, err := types.BigFromString(cctx.String("gas-premium"))
+			if err != nil {
+				return err
+			}
+			params.GasPremium = &gp
+		}
+
+		params.GasFeeCap = &zero
+		if cctx.IsSet("gas-feecap") {
+			gfc, err := types.BigFromString(cctx.String("gas-feecap"))
+			if err != nil {
+				return err
+			}
+			params.GasFeeCap = &gfc
+		}
+
+		var limit int64 = 0
+		params.GasLimit = &limit
+		if cctx.IsSet("gas-limit") {
+			limit := cctx.Int64("gas-limit")
+			params.GasLimit = &limit
+		}
+
+		if cctx.IsSet("params-json") {
+			decparams, err := srv.DecodeTypedParamsFromJSON(ctx, params.To, params.Method, cctx.String("params-json"))
+			if err != nil {
+				return fmt.Errorf("failed to decode json params: %w", err)
+			}
+			params.Params = decparams
+		}
+		if cctx.IsSet("params-hex") {
+			if params.Params != nil {
+				return fmt.Errorf("can only specify one of 'params-json' and 'params-hex'")
+			}
+			decparams, err := hex.DecodeString(cctx.String("params-hex"))
+			if err != nil {
+				return fmt.Errorf("failed to decode hex params: %w", err)
+			}
+			params.Params = decparams
+		}
+
+		if cctx.IsSet("nonce") {
+			n := cctx.Uint64("nonce")
+			params.Nonce = &n
+		}
+
+		codeCid, err := cid.Decode(cctx.Args().Get(0))
+		if err != nil {
+			return xerrors.Errorf("error parsing codeCid for actor")
+		}
+
+		initParams := &init_.ExecParams{
+			CodeCID:           codeCid,
+			ConstructorParams: params.Params,
+		}
+		serparams, err := actors.SerializeParams(initParams)
+		if err != nil {
+			return xerrors.Errorf("failed serializing init actor params: %s", err)
+		}
+
+		// Init actor is responsible for the deployment of new actors.
+		smsg, aerr := api.MpoolPushMessage(ctx, &types.Message{
+			To:         spec_builtin.InitActorAddr,
+			From:       params.From,
+			Value:      big.Zero(),
+			Method:     spec_builtin.MethodsInit.Exec,
+			Params:     serparams,
+			GasLimit:   *params.GasLimit,
+			GasFeeCap:  *params.GasFeeCap,
+			GasPremium: *params.GasPremium,
+		}, nil)
+		if aerr != nil {
+			return xerrors.Errorf("Error sending message: %s", aerr)
+		}
+
+		msg := smsg.Cid()
+		mw, aerr := api.StateWaitMsg(ctx, msg, build.MessageConfidence)
+		if aerr != nil {
+			return xerrors.Errorf("Error waiting msg: %s", aerr)
+		}
+
+		r := &init_.ExecReturn{}
+		if err := r.UnmarshalCBOR(bytes.NewReader(mw.Receipt.Return)); err != nil {
+			return err
+		}
+		fmt.Fprintf(cctx.App.Writer, "Successfully deployed actor with address: %s\n", r.IDAddress)
 		return nil
 	},
 }

--- a/node/impl/hierarchical/subnet.go
+++ b/node/impl/hierarchical/subnet.go
@@ -91,13 +91,20 @@ func (a *HierarchicalAPI) LockState(
 	subnet address.SubnetID, method abi.MethodNum) (cid.Cid, error) {
 	return a.Sub.LockState(ctx, wallet, actor, subnet, method)
 }
+
+func (a *HierarchicalAPI) UnlockState(
+	ctx context.Context, wallet address.Address, actor address.Address,
+	subnet address.SubnetID, method abi.MethodNum) error {
+	return a.Sub.UnlockState(ctx, wallet, actor, subnet, method)
+}
+
 func (a *HierarchicalAPI) InitAtomicExec(
 	ctx context.Context, wallet address.Address, inputs map[string]sca.LockedState,
 	msgs []types.Message) (cid.Cid, error) {
 	return a.Sub.InitAtomicExec(ctx, wallet, inputs, msgs)
 }
 
-func (a *HierarchicalAPI) ListAtomicExecs(ctx context.Context, id address.SubnetID, addr address.Address) ([]*sca.AtomicExec, error) {
+func (a *HierarchicalAPI) ListAtomicExecs(ctx context.Context, id address.SubnetID, addr address.Address) ([]sca.AtomicExec, error) {
 	return a.Sub.ListAtomicExecs(ctx, id, addr)
 }
 

--- a/node/impl/hierarchical/subnet.go
+++ b/node/impl/hierarchical/subnet.go
@@ -84,3 +84,9 @@ func (a *HierarchicalAPI) CrossMsgResolve(ctx context.Context, id address.Subnet
 	c cid.Cid, from address.SubnetID) ([]types.Message, error) {
 	return a.Sub.CrossMsgResolve(ctx, id, c, from)
 }
+
+func (a *HierarchicalAPI) LockState(
+	ctx context.Context, wallet address.Address, actor address.Address,
+	subnet address.SubnetID, method abi.MethodNum) (cid.Cid, error) {
+	return a.Sub.LockState(ctx, wallet, actor, subnet, method)
+}

--- a/node/impl/hierarchical/subnet.go
+++ b/node/impl/hierarchical/subnet.go
@@ -6,6 +6,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/checkpoints/schema"
 	snmgr "github.com/filecoin-project/lotus/chain/consensus/hierarchical/subnet/manager"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -89,4 +90,23 @@ func (a *HierarchicalAPI) LockState(
 	ctx context.Context, wallet address.Address, actor address.Address,
 	subnet address.SubnetID, method abi.MethodNum) (cid.Cid, error) {
 	return a.Sub.LockState(ctx, wallet, actor, subnet, method)
+}
+func (a *HierarchicalAPI) InitAtomicExec(
+	ctx context.Context, wallet address.Address, inputs map[string]sca.LockedState,
+	msgs []types.Message) (cid.Cid, error) {
+	return a.Sub.InitAtomicExec(ctx, wallet, inputs, msgs)
+}
+
+func (a *HierarchicalAPI) ListAtomicExecs(ctx context.Context, id address.SubnetID, addr address.Address) ([]*sca.AtomicExec, error) {
+	return a.Sub.ListAtomicExecs(ctx, id, addr)
+}
+
+func (a *HierarchicalAPI) ComputeAndSubmitExec(ctx context.Context, wallet address.Address,
+	id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error) {
+	return a.Sub.ComputeAndSubmitExec(ctx, wallet, id, execID)
+}
+
+func (a *HierarchicalAPI) AbortAtomicExec(ctx context.Context, wallet address.Address,
+	id address.SubnetID, execID cid.Cid) (sca.ExecStatus, error) {
+	return a.Sub.AbortAtomicExec(ctx, wallet, id, execID)
 }


### PR DESCRIPTION
This PR:
- [x] Includes `subnet atomic` command group to orchestrate and run atomic executions. 
- [x] Includes new commands to deploy new actors in subnets and compute the hierarchical address for a raw address in a subnet.
- [x] Includes support to request locked states in the subnet's content resolution protocol.
- [x] Includes improvements in usability of the locking primitives