### PR TITLE
fix #172: error loading subnet state in node restart

### DIFF
--- a/chain/consensus/hierarchical/subnet/manager/manager.go
+++ b/chain/consensus/hierarchical/subnet/manager/manager.go
@@ -221,6 +221,10 @@ func (s *SubnetMgr) startSubnet(id address.SubnetID,
 		log.Errorw("Error creating state manager for subnet", "subnetID", id, "err", err)
 		return err
 	}
+	err = sh.ch.Load(ctx)
+	if err != nil {
+		return xerrors.Errorf("Error loading chain from disk: %w", err)
+	}
 	// Start state manager.
 	sh.sm.Start(ctx)
 


### PR DESCRIPTION
fix #172: The chain state for subnets wasn't being re-loaded between restarts.  