### PR TITLE
Fix potential data race via logger

### DIFF
--- a/chain/consensus/delegcns/mine.go
+++ b/chain/consensus/delegcns/mine.go
@@ -16,7 +16,7 @@ import (
 )
 
 func Mine(ctx context.Context, addr address.Address, api v1api.FullNode) error {
-	log = logging.FromContext(ctx, log)
+	log := logging.FromContext(ctx, log)
 
 	head, err := api.ChainHead(ctx)
 	if err != nil {

--- a/chain/consensus/mir/mine.go
+++ b/chain/consensus/mir/mine.go
@@ -38,7 +38,7 @@ import (
 //    are received via state, after each validator joins the subnet.
 //    This is used to run Mir in a subnet.
 func Mine(ctx context.Context, addr address.Address, api v1api.FullNode) error {
-	log = logging.FromContext(ctx, log)
+	log := logging.FromContext(ctx, log)
 
 	m, err := newMiner(ctx, addr, api)
 	if err != nil {

--- a/chain/consensus/tendermint/mine.go
+++ b/chain/consensus/tendermint/mine.go
@@ -23,7 +23,7 @@ const (
 )
 
 func Mine(ctx context.Context, miner address.Address, api v1api.FullNode) error {
-	log = logging.FromContext(ctx, log)
+	log := logging.FromContext(ctx, log)
 
 	var cache = newMessageCache()
 

--- a/chain/consensus/tspow/mine.go
+++ b/chain/consensus/tspow/mine.go
@@ -19,7 +19,7 @@ import (
 )
 
 func Mine(ctx context.Context, miner address.Address, api v1api.FullNode) error {
-	log = logging.FromContext(ctx, log)
+	log := logging.FromContext(ctx, log)
 
 	head, err := api.ChainHead(ctx)
 	if err != nil {


### PR DESCRIPTION
This PR fixes potential data races via logger passed via. context. Races can happen if the same consensus protocol is used in several subnets: e.g., in the rootnet in a subnet. 
