### PR TITLE
Revert race mode for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
         default: golang
       go-test-flags:
         type: string
-        default: "-race -tags=2k -timeout 30m"
+        default: "-tags=2k -timeout 30m"
         description: Flags passed to go test.
       target:
         type: string


### PR DESCRIPTION
This PR reverts run tests with the `race` flag temporarily.