### PR TITLE
Removing cross-messages from blocks

### DIFF
--- a/api/api_full.go
+++ b/api/api_full.go
@@ -831,7 +831,6 @@ type MsgGasCost struct {
 type BlockMessages struct {
 	BlsMessages   []*types.Message
 	SecpkMessages []*types.SignedMessage
-	CrossMessages []*types.Message
 
 	Cids []cid.Cid
 }

--- a/chain/consensus/benchmark/benchmark.go
+++ b/chain/consensus/benchmark/benchmark.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	lapi "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/consensus/hierarchical"
 )
 
 func RunSimpleBenchmark(ctx context.Context, api lapi.FullNode, benchmarkLength int) (TestnetStats, error) {
@@ -26,9 +27,14 @@ func RunSimpleBenchmark(ctx context.Context, api lapi.FullNode, benchmarkLength 
 				if err != nil {
 					return err
 				}
-				crossMsgsNum += len(msgs.CrossMessages)
 				blsMsgsNum += len(msgs.BlsMessages)
-				secpkMsgsNum += len(msgs.SecpkMessages)
+				for _, m := range msgs.SecpkMessages {
+					if hierarchical.IsCrossMsg(&m.Message) {
+						crossMsgsNum += 1
+					} else {
+						secpkMsgsNum += 1
+					}
+				}
 			}
 		}
 		return nil

--- a/chain/consensus/benchmark/benchmark.go
+++ b/chain/consensus/benchmark/benchmark.go
@@ -30,9 +30,9 @@ func RunSimpleBenchmark(ctx context.Context, api lapi.FullNode, benchmarkLength 
 				blsMsgsNum += len(msgs.BlsMessages)
 				for _, m := range msgs.SecpkMessages {
 					if hierarchical.IsCrossMsg(&m.Message) {
-						crossMsgsNum += 1
+						crossMsgsNum++
 					} else {
-						secpkMsgsNum += 1
+						secpkMsgsNum++
 					}
 				}
 			}

--- a/chain/consensus/common/mine.go
+++ b/chain/consensus/common/mine.go
@@ -66,8 +66,8 @@ func PrepareBlockForSignature(ctx context.Context, sm *stmgr.StateManager, bt *l
 	}
 
 	for _, msg := range bt.CrossMessages {
-		m := &types.SignedMessage{Message: *msg, Signature: crypto.Signature{Type: crypto.SigTypeUnknown}}
-		c, err := sm.ChainStore().PutMessage(ctx, msg)
+		m := &types.SignedMessage{Message: *msg, Signature: crypto.Signature{Type: crypto.SigTypeSecp256k1}}
+		c, err := sm.ChainStore().PutMessage(ctx, m)
 		if err != nil {
 			return nil, err
 		}

--- a/chain/consensus/filcns/mine.go
+++ b/chain/consensus/filcns/mine.go
@@ -96,15 +96,10 @@ func (filec *FilecoinEC) CreateBlock(ctx context.Context, w api.Wallet, bt *api.
 	if err != nil {
 		return nil, xerrors.Errorf("building secpk amt: %w", err)
 	}
-	crossmsgroot, err := consensus.ToMessagesArray(store, crossMsgCids)
-	if err != nil {
-		return nil, xerrors.Errorf("building cross amt: %w", err)
-	}
 
 	mmcid, err := store.Put(store.Context(), &types.MsgMeta{
 		BlsMessages:   blsmsgroot,
 		SecpkMessages: secpkmsgroot,
-		CrossMessages: crossmsgroot,
 	})
 	if err != nil {
 		return nil, err
@@ -147,7 +142,6 @@ func (filec *FilecoinEC) CreateBlock(ctx context.Context, w api.Wallet, bt *api.
 		Header:        next,
 		BlsMessages:   blsMessages,
 		SecpkMessages: secpkMessages,
-		CrossMessages: bt.CrossMessages,
 	}
 
 	return fullBlock, nil

--- a/chain/consensus/filcns/mine.go
+++ b/chain/consensus/filcns/mine.go
@@ -51,7 +51,7 @@ func (filec *FilecoinEC) CreateBlock(ctx context.Context, w api.Wallet, bt *api.
 	var blsMessages []*types.Message
 	var secpkMessages []*types.SignedMessage
 
-	var blsMsgCids, secpkMsgCids, crossMsgCids []cid.Cid
+	var blsMsgCids, secpkMsgCids []cid.Cid
 	var blsSigs []crypto.Signature
 	for _, msg := range bt.Messages {
 		if msg.Signature.Type == crypto.SigTypeBLS {
@@ -79,12 +79,13 @@ func (filec *FilecoinEC) CreateBlock(ctx context.Context, w api.Wallet, bt *api.
 	}
 
 	for _, msg := range bt.CrossMessages {
-		c, err := filec.sm.ChainStore().PutMessage(ctx, msg)
+		m := &types.SignedMessage{Message: *msg, Signature: crypto.Signature{Type: crypto.SigTypeSecp256k1}}
+		c, err := filec.sm.ChainStore().PutMessage(ctx, m)
 		if err != nil {
 			return nil, err
 		}
-
-		crossMsgCids = append(crossMsgCids, c)
+		secpkMsgCids = append(secpkMsgCids, c)
+		secpkMessages = append(secpkMessages, m)
 	}
 
 	store := filec.sm.ChainStore().ActorStore(ctx)

--- a/chain/consensus/genesis/genesis.go
+++ b/chain/consensus/genesis/genesis.go
@@ -590,7 +590,6 @@ func MakeGenesisBlock(ctx context.Context, j journal.Journal, bs bstore.Blocksto
 	mm := &types.MsgMeta{
 		BlsMessages:   emptyroot,
 		SecpkMessages: emptyroot,
-		CrossMessages: emptyroot,
 	}
 	mmb, err := mm.ToStorageBlock()
 	if err != nil {

--- a/chain/consensus/hierarchical/actors/subnet/genesis.go
+++ b/chain/consensus/hierarchical/actors/subnet/genesis.go
@@ -74,7 +74,6 @@ func makeGenesisBlock(
 	mm := &types.MsgMeta{
 		BlsMessages:   emptyRoot,
 		SecpkMessages: emptyRoot,
-		CrossMessages: emptyRoot,
 	}
 	mmb, err := mm.ToStorageBlock()
 	if err != nil {

--- a/chain/consensus/hierarchical/atomic/exec/exec_test.go
+++ b/chain/consensus/hierarchical/atomic/exec/exec_test.go
@@ -379,7 +379,6 @@ func makeDelegatedGenesisBlock(ctx context.Context, bs blockstore.Blockstore, te
 	mm := &types.MsgMeta{
 		BlsMessages:   emptyroot,
 		SecpkMessages: emptyroot,
-		CrossMessages: emptyroot,
 	}
 	mmb, err := mm.ToStorageBlock()
 	if err != nil {

--- a/chain/consensus/hierarchical/types.go
+++ b/chain/consensus/hierarchical/types.go
@@ -137,7 +137,7 @@ func GetMsgType(msg *types.Message) MsgType {
 func IsCrossMsg(msg *types.Message) bool {
 	_, errf := msg.From.Subnet()
 	_, errt := msg.To.Subnet()
-	return errf == address.ErrNotHierarchical && errt == address.ErrNotHierarchical
+	return errf == nil && errt == nil
 }
 
 func UnbundleCrossAndSecpMsgs(msgs []types.ChainMsg) (secp []types.ChainMsg, cross []types.ChainMsg) {

--- a/chain/consensus/hierarchical/types.go
+++ b/chain/consensus/hierarchical/types.go
@@ -134,6 +134,23 @@ func GetMsgType(msg *types.Message) MsgType {
 	return TopDown
 }
 
+func IsCrossMsg(msg *types.Message) bool {
+	_, errf := msg.From.Subnet()
+	_, errt := msg.To.Subnet()
+	return errf == address.ErrNotHierarchical && errt == address.ErrNotHierarchical
+}
+
+func UnbundleCrossAndSecpMsgs(msgs []types.ChainMsg) (secp []types.ChainMsg, cross []types.ChainMsg) {
+	for _, cm := range msgs {
+		if IsCrossMsg(cm.VMMessage()) {
+			cross = append(cross, cm)
+		} else {
+			secp = append(secp, cm)
+		}
+	}
+	return
+}
+
 // SubnetCoordActorAddr is the address of the SCA actor in a subnet. It is initialized in genesis with the address t064.
 var SubnetCoordActorAddr = func() address.Address {
 	a, err := address.NewIDAddress(64)

--- a/chain/consensus/hierarchical/types_test.go
+++ b/chain/consensus/hierarchical/types_test.go
@@ -38,3 +38,19 @@ func testApplyAsBottomUp(t *testing.T, curr, from, to string, bottomup bool) {
 	require.NoError(t, err)
 	require.Equal(t, bu, bottomup)
 }
+
+func TestIsCrossMsg(t *testing.T) {
+	ff, _ := address.NewHCAddress(address.SubnetID("/root/a"), tutil.NewIDAddr(t, 101))
+	tt, _ := address.NewHCAddress(address.SubnetID("/root/b"), tutil.NewIDAddr(t, 101))
+	msg := types.Message{From: ff, To: tt}
+	require.Equal(t, hierarchical.IsCrossMsg(&msg), true)
+
+	ff = tutil.NewIDAddr(t, 101)
+	msg = types.Message{From: ff, To: tt}
+	require.Equal(t, hierarchical.IsCrossMsg(&msg), false)
+
+	ff = tutil.NewIDAddr(t, 101)
+	tt = tutil.NewIDAddr(t, 102)
+	msg = types.Message{From: ff, To: tt}
+	require.Equal(t, hierarchical.IsCrossMsg(&msg), false)
+}

--- a/chain/consensus/tendermint/mine.go
+++ b/chain/consensus/tendermint/mine.go
@@ -263,9 +263,6 @@ func (tm *Tendermint) CreateBlock(ctx context.Context, w lapi.Wallet, bt *lapi.B
 	if validMsgs.SecpkMessages != nil {
 		b.SecpkMessages = validMsgs.SecpkMessages
 	}
-	if validMsgs.CrossMsgs != nil {
-		b.CrossMessages = validMsgs.CrossMsgs
-	}
 
 	log.Infof("%s mined a block", b.Header.Miner)
 

--- a/chain/exchange/cbor_gen.go
+++ b/chain/exchange/cbor_gen.go
@@ -271,7 +271,7 @@ func (t *Response) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufCompactedMessages = []byte{134}
+var lengthBufCompactedMessages = []byte{132}
 
 func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -358,7 +358,6 @@ func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -381,7 +380,7 @@ func (t *CompactedMessages) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 6 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 

--- a/chain/exchange/cbor_gen.go
+++ b/chain/exchange/cbor_gen.go
@@ -359,42 +359,6 @@ func (t *CompactedMessages) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.Cross ([]*types.Message) (slice)
-	if len(t.Cross) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.Cross was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Cross))); err != nil {
-		return err
-	}
-	for _, v := range t.Cross {
-		if err := v.MarshalCBOR(cw); err != nil {
-			return err
-		}
-	}
-
-	// t.CrossIncludes ([][]uint64) (slice)
-	if len(t.CrossIncludes) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.CrossIncludes was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.CrossIncludes))); err != nil {
-		return err
-	}
-	for _, v := range t.CrossIncludes {
-		if len(v) > cbg.MaxLength {
-			return xerrors.Errorf("Slice value in field v was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(v))); err != nil {
-			return err
-		}
-		for _, v := range v {
-			if err := cw.CborWriteHeader(cbg.MajUnsignedInt, uint64(v)); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }
 
@@ -592,94 +556,6 @@ func (t *CompactedMessages) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 				t.SecpkIncludes[i][j] = uint64(val)
-			}
-
-		}
-	}
-
-	// t.Cross ([]*types.Message) (slice)
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.Cross: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.Cross = make([]*types.Message, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-
-		var v types.Message
-		if err := v.UnmarshalCBOR(cr); err != nil {
-			return err
-		}
-
-		t.Cross[i] = &v
-	}
-
-	// t.CrossIncludes ([][]uint64) (slice)
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.CrossIncludes: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.CrossIncludes = make([][]uint64, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-
-			if extra > cbg.MaxLength {
-				return fmt.Errorf("t.CrossIncludes[i]: array too large (%d)", extra)
-			}
-
-			if maj != cbg.MajArray {
-				return fmt.Errorf("expected cbor array")
-			}
-
-			if extra > 0 {
-				t.CrossIncludes[i] = make([]uint64, extra)
-			}
-
-			for j := 0; j < int(extra); j++ {
-
-				maj, val, err := cr.ReadHeader()
-				if err != nil {
-					return xerrors.Errorf("failed to read uint64 for t.CrossIncludes[i] slice: %w", err)
-				}
-
-				if maj != cbg.MajUnsignedInt {
-					return xerrors.Errorf("value read for array t.CrossIncludes[i] was not a uint, instead got %d", maj)
-				}
-
-				t.CrossIncludes[i][j] = uint64(val)
 			}
 
 		}

--- a/chain/exchange/client.go
+++ b/chain/exchange/client.go
@@ -296,11 +296,6 @@ func (c *client) validateCompressedIndices(chain []*BSTipSet) error {
 				len(msgs.SecpkIncludes), blocksNum)
 		}
 
-		if len(msgs.CrossIncludes) != blocksNum {
-			return xerrors.Errorf("CrossIncludes (%d) does not match number of blocks (%d)",
-				len(msgs.CrossIncludes), blocksNum)
-		}
-
 		for blockIdx := 0; blockIdx < blocksNum; blockIdx++ {
 			for _, mi := range msgs.BlsIncludes[blockIdx] {
 				if int(mi) >= len(msgs.Bls) {
@@ -313,12 +308,6 @@ func (c *client) validateCompressedIndices(chain []*BSTipSet) error {
 				if int(mi) >= len(msgs.Secpk) {
 					return xerrors.Errorf("index in SecpkIncludes (%d) exceeds number of messages (%d)",
 						mi, len(msgs.Secpk))
-				}
-			}
-			for _, mi := range msgs.CrossIncludes[blockIdx] {
-				if int(mi) >= len(msgs.Cross) {
-					return xerrors.Errorf("index in CrossIncludes (%d) exceeds number of messages (%d)",
-						mi, len(msgs.Cross))
 				}
 			}
 		}

--- a/chain/exchange/protocol.go
+++ b/chain/exchange/protocol.go
@@ -163,9 +163,6 @@ type CompactedMessages struct {
 
 	Secpk         []*types.SignedMessage
 	SecpkIncludes [][]uint64
-
-	Cross         []*types.Message
-	CrossIncludes [][]uint64
 }
 
 // Response that has been validated according to the protocol
@@ -200,9 +197,6 @@ func (res *validatedResponse) toFullTipSets() []*store.FullTipSet {
 			}
 			for _, mi := range msgs.SecpkIncludes[blockIdx] {
 				fb.SecpkMessages = append(fb.SecpkMessages, msgs.Secpk[mi])
-			}
-			for _, mi := range msgs.CrossIncludes[blockIdx] {
-				fb.CrossMessages = append(fb.CrossMessages, msgs.Cross[mi])
 			}
 
 			fts.Blocks = append(fts.Blocks, fb)

--- a/chain/gen/genesis/genesis.go
+++ b/chain/gen/genesis/genesis.go
@@ -589,7 +589,6 @@ func MakeGenesisBlock(ctx context.Context, j journal.Journal, bs bstore.Blocksto
 	mm := &types.MsgMeta{
 		BlsMessages:   emptyroot,
 		SecpkMessages: emptyroot,
-		CrossMessages: emptyroot,
 	}
 	mmb, err := mm.ToStorageBlock()
 	if err != nil {

--- a/chain/store/basefee.go
+++ b/chain/store/basefee.go
@@ -58,8 +58,8 @@ func (cs *ChainStore) ComputeBaseFee(ctx context.Context, ts *types.TipSet) (abi
 	seen := make(map[cid.Cid]struct{})
 
 	for _, b := range ts.Blocks() {
-		// NOTE XXX: Cross-messages doesn't account for basefee?
-		msg1, msg2, _, err := cs.MessagesForBlock(ctx, b)
+		// cross-net message apply equally to the basefee of the network.
+		msg1, msg2, err := cs.MessagesForBlock(ctx, b)
 		if err != nil {
 			return zero, xerrors.Errorf("error getting messages for: %s: %w", b.Cid(), err)
 		}

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -1112,7 +1112,7 @@ func (cs *ChainStore) TryFillTipSet(ctx context.Context, ts *types.TipSet) (*Ful
 	var out []*types.FullBlock
 
 	for _, b := range ts.Blocks() {
-		bmsgs, smsgs, crossmsg, err := cs.MessagesForBlock(ctx, b)
+		bmsgs, smsgs, err := cs.MessagesForBlock(ctx, b)
 		if err != nil {
 			// TODO: check for 'not found' errors, and only return nil if this
 			// is actually a 'not found' error
@@ -1123,7 +1123,6 @@ func (cs *ChainStore) TryFillTipSet(ctx context.Context, ts *types.TipSet) (*Ful
 			Header:        b,
 			BlsMessages:   bmsgs,
 			SecpkMessages: smsgs,
-			CrossMessages: crossmsg,
 		}
 
 		out = append(out, fb)

--- a/chain/types/blockheader.go
+++ b/chain/types/blockheader.go
@@ -131,7 +131,6 @@ func (blk *BlockHeader) IsValidated() bool {
 type MsgMeta struct {
 	BlsMessages   cid.Cid
 	SecpkMessages cid.Cid
-	CrossMessages cid.Cid
 }
 
 func (mm *MsgMeta) Cid() cid.Cid {

--- a/chain/types/cbor_gen.go
+++ b/chain/types/cbor_gen.go
@@ -1072,12 +1072,6 @@ func (t *MsgMeta) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.SecpkMessages: %w", err)
 	}
 
-	// t.CrossMessages (cid.Cid) (struct)
-
-	if err := cbg.WriteCid(cw, t.CrossMessages); err != nil {
-		return xerrors.Errorf("failed to write cid field t.CrossMessages: %w", err)
-	}
-
 	return nil
 }
 
@@ -1126,18 +1120,6 @@ func (t *MsgMeta) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		t.SecpkMessages = c
-
-	}
-	// t.CrossMessages (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(cr)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.CrossMessages: %w", err)
-		}
-
-		t.CrossMessages = c
 
 	}
 	return nil
@@ -1450,19 +1432,6 @@ func (t *BlockMsg) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.CrossMessages ([]cid.Cid) (slice)
-	if len(t.CrossMessages) > cbg.MaxLength {
-		return xerrors.Errorf("Slice value in field t.CrossMessages was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.CrossMessages))); err != nil {
-		return err
-	}
-	for _, v := range t.CrossMessages {
-		if err := cbg.WriteCid(w, v); err != nil {
-			return xerrors.Errorf("failed writing cid field t.CrossMessages: %w", err)
-		}
-	}
 	return nil
 }
 
@@ -1562,34 +1531,6 @@ func (t *BlockMsg) UnmarshalCBOR(r io.Reader) (err error) {
 			return xerrors.Errorf("reading cid field t.SecpkMessages failed: %w", err)
 		}
 		t.SecpkMessages[i] = c
-	}
-
-	// t.CrossMessages ([]cid.Cid) (slice)
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.CrossMessages: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.CrossMessages = make([]cid.Cid, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-
-		c, err := cbg.ReadCid(cr)
-		if err != nil {
-			return xerrors.Errorf("reading cid field t.CrossMessages failed: %w", err)
-		}
-		t.CrossMessages[i] = c
 	}
 
 	return nil

--- a/chain/types/cbor_gen.go
+++ b/chain/types/cbor_gen.go
@@ -1046,7 +1046,7 @@ func (t *SignedMessage) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufMsgMeta = []byte{131}
+var lengthBufMsgMeta = []byte{130}
 
 func (t *MsgMeta) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -1094,7 +1094,7 @@ func (t *MsgMeta) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 3 {
+	if extra != 2 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1432,6 +1432,19 @@ func (t *BlockMsg) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
+	// t.CrossMessages ([]cid.Cid) (slice)
+	if len(t.CrossMessages) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.CrossMessages was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.CrossMessages))); err != nil {
+		return err
+	}
+	for _, v := range t.CrossMessages {
+		if err := cbg.WriteCid(w, v); err != nil {
+			return xerrors.Errorf("failed writing cid field t.CrossMessages: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -1531,6 +1544,34 @@ func (t *BlockMsg) UnmarshalCBOR(r io.Reader) (err error) {
 			return xerrors.Errorf("reading cid field t.SecpkMessages failed: %w", err)
 		}
 		t.SecpkMessages[i] = c
+	}
+
+	// t.CrossMessages ([]cid.Cid) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("t.CrossMessages: array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		t.CrossMessages = make([]cid.Cid, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+
+		c, err := cbg.ReadCid(cr)
+		if err != nil {
+			return xerrors.Errorf("reading cid field t.CrossMessages failed: %w", err)
+		}
+		t.CrossMessages[i] = c
 	}
 
 	return nil

--- a/chain/types/fullblock.go
+++ b/chain/types/fullblock.go
@@ -6,7 +6,6 @@ type FullBlock struct {
 	Header        *BlockHeader
 	BlsMessages   []*Message
 	SecpkMessages []*SignedMessage
-	CrossMessages []*Message
 }
 
 func (fb *FullBlock) Cid() cid.Cid {

--- a/node/impl/full/chain.go
+++ b/node/impl/full/chain.go
@@ -116,12 +116,12 @@ func (m *ChainModule) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*
 		return nil, err
 	}
 
-	bmsgs, smsgs, crossmsgs, err := m.Chain.MessagesForBlock(ctx, b)
+	bmsgs, smsgs, err := m.Chain.MessagesForBlock(ctx, b)
 	if err != nil {
 		return nil, err
 	}
 
-	cids := make([]cid.Cid, len(bmsgs)+len(smsgs)+len(crossmsgs))
+	cids := make([]cid.Cid, len(bmsgs)+len(smsgs))
 
 	for i, m := range bmsgs {
 		cids[i] = m.Cid()
@@ -131,14 +131,9 @@ func (m *ChainModule) ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*
 		cids[i+len(bmsgs)] = m.Cid()
 	}
 
-	for i, m := range crossmsgs {
-		cids[i+len(smsgs)] = m.Cid()
-	}
-
 	return &api.BlockMessages{
 		BlsMessages:   bmsgs,
 		SecpkMessages: smsgs,
-		CrossMessages: crossmsgs,
 		Cids:          cids,
 	}, nil
 }

--- a/node/impl/full/state.go
+++ b/node/impl/full/state.go
@@ -555,9 +555,6 @@ func (a *StateAPI) MinerCreateBlock(ctx context.Context, bt *api.BlockTemplate) 
 	for _, msg := range fblk.SecpkMessages {
 		out.SecpkMessages = append(out.SecpkMessages, msg.Cid())
 	}
-	for _, msg := range fblk.CrossMessages {
-		out.CrossMessages = append(out.CrossMessages, msg.Cid())
-	}
 
 	return &out, nil
 }

--- a/node/impl/full/sync.go
+++ b/node/impl/full/sync.go
@@ -74,16 +74,10 @@ func (a *SyncAPI) SyncSubmitBlock(ctx context.Context, blk *types.BlockMsg) erro
 		return xerrors.Errorf("failed to load secpk message: %w", err)
 	}
 
-	crossmsgs, err := a.Syncer.ChainStore().LoadMessagesFromCids(ctx, blk.CrossMessages)
-	if err != nil {
-		return xerrors.Errorf("failed to load secpk message: %w", err)
-	}
-
 	fb := &types.FullBlock{
 		Header:        blk.Header,
 		BlsMessages:   bmsgs,
 		SecpkMessages: smsgs,
-		CrossMessages: crossmsgs,
 	}
 
 	if err := a.Syncer.ValidateMsgMeta(fb); err != nil {
@@ -130,16 +124,10 @@ func (a *SyncAPI) SyncBlock(ctx context.Context, blk *types.BlockMsg) error {
 		return xerrors.Errorf("failed to load secpk message: %w", err)
 	}
 
-	crossmsgs, err := a.Syncer.ChainStore().LoadMessagesFromCids(ctx, blk.CrossMessages)
-	if err != nil {
-		return xerrors.Errorf("failed to load secpk message: %w", err)
-	}
-
 	fb := &types.FullBlock{
 		Header:        blk.Header,
 		BlsMessages:   bmsgs,
 		SecpkMessages: smsgs,
-		CrossMessages: crossmsgs,
 	}
 
 	if err := a.Syncer.ValidateMsgMeta(fb); err != nil {


### PR DESCRIPTION
Fixes:  https://github.com/filecoin-project/eudico/issues/218
- It includes cross-messages inside the Secp message field of blocks with an `unknown` signature type.
