### PR TITLE
fix atomic exec flaky test

### DIFF
--- a/chain/consensus/hierarchical/actors/sca/sca_actor.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_actor.go
@@ -708,7 +708,7 @@ func (a SubnetCoordActor) SubmitAtomicExec(rt runtime.Runtime, params *SubmitExe
 		st   SCAState
 		exec *AtomicExec
 	)
-	caller := SecpBLSAddr(rt, rt.Caller())
+	caller := rt.Caller()
 	rt.StateTransaction(&st, func() {
 		execMap, err := adt.AsMap(adt.AsStore(rt), st.AtomicExecRegistry, builtin.DefaultHamtBitwidth)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error getting exec map")

--- a/chain/consensus/hierarchical/actors/sca/sca_atomic.go
+++ b/chain/consensus/hierarchical/actors/sca/sca_atomic.go
@@ -84,7 +84,10 @@ func (ae *AtomicExecParams) translateInputAddrs(rt runtime.Runtime) {
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error parsing subnet")
 		raw, err := addr.RawAddr()
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error parsing raw address")
-		outAddr := SecpBLSAddr(rt, raw)
+		outAddr, ok := rt.ResolveAddress(raw)
+		if !ok {
+			rt.Abortf(exitcode.ErrIllegalArgument, "unable to resolve address %v", raw)
+		}
 		out, err := address.NewHCAddress(sn, outAddr)
 		builtin.RequireNoErr(rt, err, exitcode.ErrIllegalState, "error generating HCAddress")
 		aux[out.String()] = ae.Inputs[k]


### PR DESCRIPTION
Fixes #183

Note: We may still need to have a more extensive coverage of the atomic execution tests, but as we are rewriting the actors in Rust, we'll defer that to the new implementation.