### PR TITLE
Parametrize PoW to make tests faster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
   build-macos:
     description: build darwin lotus binary
     macos:
-      xcode: "12.5.0"
+      xcode: "12.5.1"
     working_directory: ~/go/src/github.com/filecoin-project/lotus
     steps:
       - prepare:

--- a/build/params_2k.go
+++ b/build/params_2k.go
@@ -134,3 +134,5 @@ const TendermintCheckpointPeriod = 10
 const MirCheckpointPeriod = 10
 const DummyCheckpointPeriod = 10
 const FilecoinCheckpointPeriod = 10
+
+const GenesisPoWTarget = "2019783675352289407433363"

--- a/build/params_mainnet.go
+++ b/build/params_mainnet.go
@@ -114,3 +114,5 @@ const TendermintCheckpointPeriod = 10
 const MirCheckpointPeriod = 10
 const DummyCheckpointPeriod = 10
 const FilecoinCheckpointPeriod = 10
+
+const GenesisPoWTarget = "4519783675352289407433363"

--- a/build/params_testground.go
+++ b/build/params_testground.go
@@ -140,3 +140,5 @@ const TendermintCheckpointPeriod = 10
 const MirCheckpointPeriod = 10
 const DummyCheckpointPeriod = 10
 const FilecoinCheckpointPeriod = 10
+
+const GenesisPoWTarget = "4519783675352289407433363"

--- a/chain/consensus/common/params/params.go
+++ b/chain/consensus/common/params/params.go
@@ -1,8 +1,11 @@
 package param
 
-import "github.com/filecoin-project/go-state-types/big"
+import (
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/build"
+)
 
 var GenesisWorkTarget = func() big.Int {
-	w, _ := big.FromString("4519783675352289407433363")
+	w, _ := big.FromString(build.GenesisPoWTarget)
 	return w
 }()

--- a/chain/consensus/tspow/pow.go
+++ b/chain/consensus/tspow/pow.go
@@ -1,0 +1,91 @@
+package tspow
+
+import (
+	"context"
+	bignumbers "math/big"
+	"sort"
+
+	"github.com/multiformats/go-multihash"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	bstore "github.com/filecoin-project/lotus/blockstore"
+	"github.com/filecoin-project/lotus/build"
+	param "github.com/filecoin-project/lotus/chain/consensus/common/params"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+func Weight(ctx context.Context, stateBs bstore.Blockstore, ts *types.TipSet) (types.BigInt, error) {
+	if ts == nil {
+		return types.NewInt(0), nil
+	}
+
+	w := ts.ParentWeight()
+	for _, header := range ts.Blocks() {
+		w = big.Add(w, work(header))
+	}
+
+	return w, nil
+}
+
+func work(bh *types.BlockHeader) big.Int {
+	w := big.NewInt(0)
+	w.SetBytes([]byte{
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	})
+
+	bhc := *bh
+	bhc.BlockSig = nil
+
+	dmh, err := multihash.Decode(bhc.Cid().Hash())
+	if err != nil {
+		panic(err) // todo probably definitely not a good idea
+	}
+	s := big.NewInt(0)
+	s.SetBytes(dmh.Digest)
+	return big.Div(w, s)
+}
+
+func DiffLookback(baseH abi.ChainEpoch) abi.ChainEpoch {
+	lb := ((baseH + 11) * 217) % (MaxDiffLookback - 40)
+	return lb + 40
+}
+
+func Difficulty(baseTs, lbts *types.TipSet) big.Int {
+	expLbTime := 100000 * uint64(DiffLookback(baseTs.Height())) * build.BlockDelaySecs
+	actTime := (baseTs.Blocks()[0].Timestamp - lbts.Blocks()[0].Timestamp) * 100000
+
+	actTime = expLbTime - uint64(int64(expLbTime-actTime)/100)
+
+	// clamp max adjustment
+	if actTime < expLbTime*99/100 {
+		actTime = expLbTime * 99 / 100
+	}
+	if actTime > expLbTime*101/100 {
+		actTime = expLbTime * 101 / 100
+	}
+
+	prevdiff := big.Zero()
+	prevdiff.SetBytes(baseTs.Blocks()[0].Ticket.VRFProof)
+	diff := big.Div(types.BigMul(prevdiff, big.NewInt(int64(expLbTime))), big.NewInt(int64(actTime)))
+
+	pgen, _ := bignumbers.NewFloat(0).SetInt(param.GenesisWorkTarget.Int).Float64()
+	fdiff, _ := bignumbers.NewFloat(0).SetInt(diff.Int).Float64()
+	pgen = fdiff * 100 / pgen
+	// Difficulty adjustement print. Really helpful for debugging purposes.
+	log.Debugf("adjust %.4f%%, p%s lb%d (%.4f%% gen)\n", 100*float64(expLbTime)/float64(actTime), prevdiff, DiffLookback(baseTs.Height()), pgen)
+
+	return diff
+}
+
+func BestWorkBlock(ts *types.TipSet) *types.BlockHeader {
+	blks := ts.Blocks()
+	sort.Slice(blks, func(i, j int) bool {
+		return work(blks[i]).GreaterThan(work(blks[j]))
+	})
+	return blks[0]
+}

--- a/chain/consensus/tspow/pow_test.go
+++ b/chain/consensus/tspow/pow_test.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/filecoin-project/go-state-types/big"
 	"github.com/ipfs/go-cid"
 
+	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
 )


### PR DESCRIPTION
The goal of this PR is to clean code style and parametrize the implementation of PoW.

Below you can see the timestamps of blocks mined by PoW on one node in our HC tests.

```
2022-08-24T10:52:06.422Z
2022-08-24T10:52:14.232Z
2022-08-24T10:52:40.816Z
2022-08-24T10:53:17.329Z
2022-08-24T10:53:36.690Z
2022-08-24T10:53:46.726Z
```

It is very inefficient to spend 30-40 seconds to mine a block in tests. 
Because of that PoW based tests often fail. 