### PR TITLE
HC: Refine subnet join parameter

### DIFF
--- a/chain/consensus/hierarchical/actors/subnet/gen/gen.go
+++ b/chain/consensus/hierarchical/actors/subnet/gen/gen.go
@@ -10,6 +10,7 @@ func main() {
 	if err := gen.WriteTupleEncodersToFile("./cbor_gen.go", "subnet",
 		actor.SubnetState{},
 		actor.ConstructParams{},
+		actor.JoinParams{},
 		actor.CheckVotes{},
 	); err != nil {
 		panic(err)

--- a/chain/consensus/hierarchical/actors/subnet/iface.go
+++ b/chain/consensus/hierarchical/actors/subnet/iface.go
@@ -2,14 +2,13 @@ package subnet
 
 import (
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/lotus/chain/consensus/hierarchical"
 	"github.com/filecoin-project/lotus/chain/consensus/hierarchical/actors/sca"
 	"github.com/filecoin-project/specs-actors/v7/actors/runtime"
 )
 
 // SubnetIface defines the minimum interface that needs to be implemented by subnet actors.
 type SubnetIface interface {
-	Join(rt runtime.Runtime, v *hierarchical.Validator) *abi.EmptyValue
+	Join(rt runtime.Runtime, params *JoinParams) *abi.EmptyValue
 	Leave(rt runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue
 	SubmitCheckpoint(rt runtime.Runtime, params *sca.CheckpointParams) *abi.EmptyValue
 	Kill(rt runtime.Runtime, _ *abi.EmptyValue) *abi.EmptyValue

--- a/chain/consensus/hierarchical/actors/subnet/subnet_state.go
+++ b/chain/consensus/hierarchical/actors/subnet/subnet_state.go
@@ -59,6 +59,7 @@ type SubnetState struct {
 	MinMinerStake abi.TokenAmount
 	// List of miners in the subnet.
 	// NOTE: Consider using AMT.
+	// TODO: This field is superseded by ValidatorSet; remove it.
 	Miners []address.Address
 	// Total collateral currently deposited in the
 	TotalStake abi.TokenAmount

--- a/chain/consensus/mir/utils.go
+++ b/chain/consensus/mir/utils.go
@@ -40,7 +40,7 @@ func getSubnetValidators(
 		}
 		validators, err = api.SubnetStateGetValidators(ctx, subnetID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get validators from state")
+			return nil, fmt.Errorf("failed to get validators from state: %w", err)
 		}
 	}
 	return hierarchical.NewValidatorSet(validators), nil

--- a/itests/eudico_hc_test.go
+++ b/itests/eudico_hc_test.go
@@ -709,7 +709,7 @@ func (ts *eudicoSubnetSuite) testMirReconfiguration(t *testing.T) {
 func runDataRacesTests(t *testing.T, opts ...interface{}) {
 	ts := eudicoSubnetSuite{opts: opts}
 
-	t.Run("testMirReconfiguration", ts.testDataRaces)
+	t.Run("testDataRaces", ts.testDataRaces)
 }
 
 // testDataRaces explores data-races on adding, joining and starting subnets in best-effort manner.


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

https://github.com/adlrocha/hc-subnet-actor/issues/2

## Proposed Changes
<!-- provide a clear list of the changes being made-->

Introducing `JoinParams` to use in place of `Validator` in subnet `Join` method.

## Additional Info
<!-- callouts, links to documentation, and etc-->

## Checklist

Before you mark the PR ready for review, please make sure that:
- [ ] All commits have a clear commit message.
- [ ] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [ ] This PR has tests for new functionality or change in behaviour
- [ ] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
